### PR TITLE
Blender 2.80 support.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,7 @@ bl_info = {
     "name": "Importer and exporter for Blizzard's Starcraft 2 model files (*.m3)",
     'author': 'Florian Köberle, netherh, chaos2night, Talv',
     "version": (0, 2, 0),
-    "blender": (2, 70, 0),
+    "blender": (2, 80, 0),
     "location": "Properties Editor -> Scene -> M3 Panels",
     "description": "Allows to export (and import) simple Starcraft 2 models (.m3) with particle systems. Use on own risk!",
     "category": "Import-Export",
@@ -810,16 +810,16 @@ def selectBone(scene, boneName):
     if bpy.ops.object.select_all.poll():
         bpy.ops.object.select_all(action='DESELECT')
     
-    armature.select = True
-    scene.objects.active = armature
+    armature.select_set(True)
+    scene.view_layers[0].objects.active = armature
     
     if bpy.ops.object.mode_set.poll():
         bpy.ops.object.mode_set(mode='POSE')
     
     for b in armature.data.bones:
-        b.select = False
+        b.select_set(False)
     
-    bone.select = True
+    bone.select_set(True)
     
 def removeBone(scene, boneName):
     "removes the given bone if it exists"
@@ -832,8 +832,8 @@ def removeBone(scene, boneName):
     if bpy.ops.object.select_all.poll():
         bpy.ops.object.select_all(action='DESELECT')
     
-    armatureObject.select = True
-    scene.objects.active = armatureObject
+    armatureObject.select_set(True)
+    scene.view_layers[0].objects.active = armatureObject
     
     if bpy.ops.object.mode_set.poll():
         bpy.ops.object.mode_set(mode='EDIT')
@@ -856,20 +856,20 @@ def selectOrCreateBone(scene, boneName):
     boneExists = bone != None
     if boneExists:
         armature = armatureObject.data
-        armatureObject.select = True
-        scene.objects.active = armatureObject
+        armatureObject.select_set(True)
+        scene.view_layers[0].objects.active = armatureObject
     else:
         armatureObject = shared.findArmatureObjectForNewBone(scene)
         if armatureObject == None:
             armature = bpy.data.armatures.new(name="Armature")
             armatureObject = bpy.data.objects.new("Armature", armature)
-            scene.objects.link(armatureObject)
+            scene.collection.objects.link(armatureObject)
         else:
             armature = armatureObject.data
-        armatureObject.select = True
-        scene.objects.active = armatureObject
+        armatureObject.select_set(True)
+        scene.view_layers[0].objects.active = armatureObject
         bpy.ops.object.mode_set(mode='EDIT')
-        editBone = armature.edit_bones.new(boneName)
+        editBone = armature.edit_bones.new(name = boneName)
         editBone.head = (0, 0, 0)
         editBone.tail = (1, 0, 0)
 
@@ -883,8 +883,8 @@ def selectOrCreateBone(scene, boneName):
         boneOfArmature.select = isBoneToSelect
     armature.bones.active = bone
         
-    scene.objects.active = armatureObject
-    armatureObject.select = True
+    scene.view_layers[0].objects.active = armatureObject
+    armatureObject.select_set(True)
     for currentBone in armature.bones:
         currentBone.select = currentBone.name == boneName
     poseBone = armatureObject.pose.bones[boneName]
@@ -898,12 +898,12 @@ def selectBoneIfItExists(scene, boneName):
         bpy.ops.object.select_all(action='DESELECT')
     bone, armatureObject = shared.findBoneWithArmatureObject(scene, boneName)
     armature = armatureObject.data
-    armatureObject.select = True
-    scene.objects.active = armatureObject
+    armatureObject.select_set(True)
+    scene.view_layers[0].objects.active = armatureObject
     if bpy.ops.object.mode_set.poll():
         bpy.ops.object.mode_set(mode='POSE')
-    scene.objects.active = armatureObject
-    armatureObject.select = True
+    scene.view_layers[0].objects.active = armatureObject
+    armatureObject.select_set(True)
     for currentBone in armature.bones:
         currentBone.select = currentBone.name == boneName
     
@@ -1249,570 +1249,570 @@ animationExportAmount = [(shared.exportAmountAllAnimations, "All animations", "A
 class M3AnimIdData(bpy.types.PropertyGroup):
     # animId is actually an unsigned integer but blender can store only signed ones
     # thats why the number range needs to be moved into the negative for storage
-    animIdMinus2147483648 = bpy.props.IntProperty(name="animId", options=set())
-    longAnimId = bpy.props.StringProperty(name="longAnimId", options=set())
+    animIdMinus2147483648 : bpy.props.IntProperty(name="animId", options=set())
+    longAnimId : bpy.props.StringProperty(name="longAnimId", options=set())
 
 class M3AnimatedPropertyReference(bpy.types.PropertyGroup):
-    longAnimId = bpy.props.StringProperty(name="longAnimId", options=set())
+    longAnimId : bpy.props.StringProperty(name="longAnimId", options=set())
     
 class AssignedActionOfM3Animation(bpy.types.PropertyGroup):
-    targetName = bpy.props.StringProperty(name="targetName", options=set())
-    actionName = bpy.props.StringProperty(name="actionName", options=set())
+    targetName : bpy.props.StringProperty(name="targetName", options=set())
+    actionName : bpy.props.StringProperty(name="actionName", options=set())
 
 class M3TransformationCollection(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="all", options=set())
-    animatedProperties = bpy.props.CollectionProperty(type=M3AnimatedPropertyReference, options=set())
-    runsConcurrent = bpy.props.BoolProperty(default=True, options=set())
-    priority = bpy.props.IntProperty(subtype="UNSIGNED",options=set())
+    name : bpy.props.StringProperty(name="name", default="all", options=set())
+    animatedProperties : bpy.props.CollectionProperty(type=M3AnimatedPropertyReference, options=set())
+    runsConcurrent : bpy.props.BoolProperty(default=True, options=set())
+    priority : bpy.props.IntProperty(subtype="UNSIGNED",options=set())
 
     
 class M3Animation(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Stand", options=set())
-    startFrame = bpy.props.IntProperty(subtype="UNSIGNED", options=set())
-    useSimulateFrame = bpy.props.BoolProperty(default=False, options=set())
-    simulateFrame = bpy.props.IntProperty(subtype="UNSIGNED", default=0, options=set())
-    exlusiveEndFrame = bpy.props.IntProperty(subtype="UNSIGNED", options=set())
-    assignedActions = bpy.props.CollectionProperty(type=AssignedActionOfM3Animation, options=set())
-    transformationCollections = bpy.props.CollectionProperty(type=M3TransformationCollection, options=set())
-    transformationCollectionIndex = bpy.props.IntProperty(default=0, options=set())
-    movementSpeed = bpy.props.FloatProperty(name="mov. speed", options=set())
-    frequency = bpy.props.IntProperty(subtype="UNSIGNED",options=set())
-    notLooping = bpy.props.BoolProperty(options=set())
-    alwaysGlobal = bpy.props.BoolProperty(options=set())
-    globalInPreviewer = bpy.props.BoolProperty(options=set())
+    name : bpy.props.StringProperty(name="name", default="Stand", options=set())
+    startFrame : bpy.props.IntProperty(subtype="UNSIGNED", options=set())
+    useSimulateFrame : bpy.props.BoolProperty(default=False, options=set())
+    simulateFrame : bpy.props.IntProperty(subtype="UNSIGNED", default=0, options=set())
+    exlusiveEndFrame : bpy.props.IntProperty(subtype="UNSIGNED", options=set())
+    assignedActions : bpy.props.CollectionProperty(type=AssignedActionOfM3Animation, options=set())
+    transformationCollections : bpy.props.CollectionProperty(type=M3TransformationCollection, options=set())
+    transformationCollectionIndex : bpy.props.IntProperty(default=0, options=set())
+    movementSpeed : bpy.props.FloatProperty(name="mov. speed", options=set())
+    frequency : bpy.props.IntProperty(subtype="UNSIGNED",options=set())
+    notLooping : bpy.props.BoolProperty(options=set())
+    alwaysGlobal : bpy.props.BoolProperty(options=set())
+    globalInPreviewer : bpy.props.BoolProperty(options=set())
 
 class M3MaterialLayer(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(default="Material Layer")
-    imagePath = bpy.props.StringProperty(name="image path", default="", options=set())
-    unknownbd3f7b5d = bpy.props.IntProperty(name="unknownbd3f7b5d", default=-1, options=set())
-    color = bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
-    textureWrapX = bpy.props.BoolProperty(options=set(), default=True)
-    textureWrapY = bpy.props.BoolProperty(options=set(), default=True)
-    invertColor = bpy.props.BoolProperty(options=set(), default=False)
-    clampColor = bpy.props.BoolProperty(options=set(), default=False)
-    colorEnabled = bpy.props.BoolProperty(options=set(), default=False)
-    uvSource = bpy.props.EnumProperty(items=uvSourceList, options=set(), default="0")
-    brightMult = bpy.props.FloatProperty(name="bright. mult.",options={"ANIMATABLE"}, default=1.0)
-    uvOffset = bpy.props.FloatVectorProperty(name="uv offset", default=(0.0, 0.0), size=2, subtype="XYZ", options={"ANIMATABLE"})
-    uvAngle = bpy.props.FloatVectorProperty(name="uv offset", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    uvTiling = bpy.props.FloatVectorProperty(name="uv tiling", default=(1.0, 1.0), size=2, subtype="XYZ", options={"ANIMATABLE"})
-    triPlanarOffset = bpy.props.FloatVectorProperty(name="tri planer offset", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    triPlanarScale = bpy.props.FloatVectorProperty(name="tri planer scale", default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    flipBookRows = bpy.props.IntProperty(name="flipBookRows", default=0, options=set())
-    flipBookColumns = bpy.props.IntProperty(name="flipBookColumns", default=0, options=set())
-    flipBookFrame = bpy.props.IntProperty(name="flipBookFrame", default=0, options={"ANIMATABLE"})
-    midtoneOffset = bpy.props.FloatProperty(name="midtone offset", options={"ANIMATABLE"}, description="Can be used to make dark areas even darker so that only the bright regions remain")
-    brightness = bpy.props.FloatProperty(name="brightness", options={"ANIMATABLE"}, default=1.0)
-    rttChannel = bpy.props.EnumProperty(items=rttChannelList, options=set(), default="-1")
-    colorChannelSetting = bpy.props.EnumProperty(items=colorChannelSettingList, options=set(), default=shared.colorChannelSettingRGB)
-    fresnelType =  bpy.props.EnumProperty(items=fresnelTypeList, options=set(), default="0")
-    invertedFresnel = bpy.props.BoolProperty(options=set())
-    fresnelExponent = bpy.props.FloatProperty(default=4.0, options=set())
-    fresnelMin = bpy.props.FloatProperty(default=0.0, options=set())
-    fresnelMax = bpy.props.FloatProperty(default=1.0, options=set())
-    fresnelMaskX = bpy.props.FloatProperty(options=set(), min=0.0, max=1.0)
-    fresnelMaskY = bpy.props.FloatProperty(options=set(), min=0.0, max=1.0)
-    fresnelMaskZ = bpy.props.FloatProperty(options=set(), min=0.0, max=1.0)
-    fresnelRotationYaw = bpy.props.FloatProperty(subtype="ANGLE", options=set())
-    fresnelRotationPitch = bpy.props.FloatProperty(subtype="ANGLE", options=set())
-    fresnelLocalTransform = bpy.props.BoolProperty(options=set(), default=False)
-    fresnelDoNotMirror = bpy.props.BoolProperty(options=set(), default=False)
-    videoFrameRate = bpy.props.IntProperty(options=set(), default=24)
-    videoStartFrame = bpy.props.IntProperty(options=set(), default=0)
-    videoEndFrame = bpy.props.IntProperty(options=set(), default=-1)
-    videoMode = bpy.props.EnumProperty(items=videoModeList, options=set(), default="0")
-    videoSyncTiming = bpy.props.BoolProperty(options=set())
-    videoPlay = bpy.props.BoolProperty(name="videoPlay", options={"ANIMATABLE"}, default=True)
-    videoRestart = bpy.props.BoolProperty(name="videoRestart", options={"ANIMATABLE"}, default=True)
+    name : bpy.props.StringProperty(default="Material Layer")
+    imagePath : bpy.props.StringProperty(name="image path", default="", options=set())
+    unknownbd3f7b5d : bpy.props.IntProperty(name="unknownbd3f7b5d", default=-1, options=set())
+    color : bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
+    textureWrapX : bpy.props.BoolProperty(options=set(), default=True)
+    textureWrapY : bpy.props.BoolProperty(options=set(), default=True)
+    invertColor : bpy.props.BoolProperty(options=set(), default=False)
+    clampColor : bpy.props.BoolProperty(options=set(), default=False)
+    colorEnabled : bpy.props.BoolProperty(options=set(), default=False)
+    uvSource : bpy.props.EnumProperty(items=uvSourceList, options=set(), default="0")
+    brightMult : bpy.props.FloatProperty(name="bright. mult.",options={"ANIMATABLE"}, default=1.0)
+    uvOffset : bpy.props.FloatVectorProperty(name="uv offset", default=(0.0, 0.0), size=2, subtype="XYZ", options={"ANIMATABLE"})
+    uvAngle : bpy.props.FloatVectorProperty(name="uv offset", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    uvTiling : bpy.props.FloatVectorProperty(name="uv tiling", default=(1.0, 1.0), size=2, subtype="XYZ", options={"ANIMATABLE"})
+    triPlanarOffset : bpy.props.FloatVectorProperty(name="tri planer offset", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    triPlanarScale : bpy.props.FloatVectorProperty(name="tri planer scale", default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    flipBookRows : bpy.props.IntProperty(name="flipBookRows", default=0, options=set())
+    flipBookColumns : bpy.props.IntProperty(name="flipBookColumns", default=0, options=set())
+    flipBookFrame : bpy.props.IntProperty(name="flipBookFrame", default=0, options={"ANIMATABLE"})
+    midtoneOffset : bpy.props.FloatProperty(name="midtone offset", options={"ANIMATABLE"}, description="Can be used to make dark areas even darker so that only the bright regions remain")
+    brightness : bpy.props.FloatProperty(name="brightness", options={"ANIMATABLE"}, default=1.0)
+    rttChannel : bpy.props.EnumProperty(items=rttChannelList, options=set(), default="-1")
+    colorChannelSetting : bpy.props.EnumProperty(items=colorChannelSettingList, options=set(), default=shared.colorChannelSettingRGB)
+    fresnelType :  bpy.props.EnumProperty(items=fresnelTypeList, options=set(), default="0")
+    invertedFresnel : bpy.props.BoolProperty(options=set())
+    fresnelExponent : bpy.props.FloatProperty(default=4.0, options=set())
+    fresnelMin : bpy.props.FloatProperty(default=0.0, options=set())
+    fresnelMax : bpy.props.FloatProperty(default=1.0, options=set())
+    fresnelMaskX : bpy.props.FloatProperty(options=set(), min=0.0, max=1.0)
+    fresnelMaskY : bpy.props.FloatProperty(options=set(), min=0.0, max=1.0)
+    fresnelMaskZ : bpy.props.FloatProperty(options=set(), min=0.0, max=1.0)
+    fresnelRotationYaw : bpy.props.FloatProperty(subtype="ANGLE", options=set())
+    fresnelRotationPitch : bpy.props.FloatProperty(subtype="ANGLE", options=set())
+    fresnelLocalTransform : bpy.props.BoolProperty(options=set(), default=False)
+    fresnelDoNotMirror : bpy.props.BoolProperty(options=set(), default=False)
+    videoFrameRate : bpy.props.IntProperty(options=set(), default=24)
+    videoStartFrame : bpy.props.IntProperty(options=set(), default=0)
+    videoEndFrame : bpy.props.IntProperty(options=set(), default=-1)
+    videoMode : bpy.props.EnumProperty(items=videoModeList, options=set(), default="0")
+    videoSyncTiming : bpy.props.BoolProperty(options=set())
+    videoPlay : bpy.props.BoolProperty(name="videoPlay", options={"ANIMATABLE"}, default=True)
+    videoRestart : bpy.props.BoolProperty(name="videoRestart", options={"ANIMATABLE"}, default=True)
 
 class M3Material(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", options=set())
-    materialType = bpy.props.IntProperty(options=set())
-    materialIndex = bpy.props.IntProperty(options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", options=set())
+    materialType : bpy.props.IntProperty(options=set())
+    materialIndex : bpy.props.IntProperty(options=set())
     
 class M3StandardMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
-    blendMode = bpy.props.EnumProperty(items=matBlendModeList, options=set(), default="0")
-    priority = bpy.props.IntProperty(options=set())
-    specularity = bpy.props.FloatProperty(name="specularity", options=set())
-    cutoutThresh = bpy.props.IntProperty(name="cutoutThresh", min=0, max=255, default=0, options=set())
-    specMult = bpy.props.FloatProperty(name="spec. mult.", options=set(), default=1.0)
-    emisMult = bpy.props.FloatProperty(name="emis. mult.", options=set(), default=1.0)
-    layerBlendType = bpy.props.EnumProperty(items=matLayerAndEmisBlendModeList, options=set(), default="2")
-    emisBlendType = bpy.props.EnumProperty(items=matLayerAndEmisBlendModeList, options=set(), default="3")
-    specType = bpy.props.EnumProperty(items=matSpecularTypeList, options=set(), default="0")
-    unfogged = bpy.props.BoolProperty(options=set(), default=True)
-    twoSided = bpy.props.BoolProperty(options=set(), default=False)
-    unshaded = bpy.props.BoolProperty(options=set(), default=False)
-    noShadowsCast = bpy.props.BoolProperty(options=set(), default=False)
-    noHitTest = bpy.props.BoolProperty(options=set(), default=False)
-    noShadowsReceived = bpy.props.BoolProperty(options=set(), default=False)
-    depthPrepass = bpy.props.BoolProperty(options=set(), default=False)
-    useTerrainHDR = bpy.props.BoolProperty(options=set(), default=False)
-    splatUVfix = bpy.props.BoolProperty(options=set(), default=False)
-    softBlending = bpy.props.BoolProperty(options=set(), default=False)
-    forParticles = bpy.props.BoolProperty(options=set(), default=False)
-    transparency = bpy.props.BoolProperty(options=set(), default=False)
-    disableSoft = bpy.props.BoolProperty(options=set(), default=False)
-    darkNormalMapping = bpy.props.BoolProperty(options=set(), default=False)
-    decalRequiredOnLowEnd = bpy.props.BoolProperty(options=set(), default=False)
-    acceptSplats = bpy.props.BoolProperty(options=set(), default=False)
-    acceptSplatsOnly = bpy.props.BoolProperty(options=set(), default=False)
-    emissiveRequiredOnLowEnd = bpy.props.BoolProperty(options=set(), default=False)
-    backgroundObject = bpy.props.BoolProperty(options=set(), default=False)
-    zpFillRequiredOnLowEnd = bpy.props.BoolProperty(options=set(), default=False)
-    excludeFromHighlighting = bpy.props.BoolProperty(options=set(), default=False)
-    clampOutput = bpy.props.BoolProperty(options=set(), default=False)
-    geometryVisible = bpy.props.BoolProperty(options=set(), default=True)
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    blendMode : bpy.props.EnumProperty(items=matBlendModeList, options=set(), default="0")
+    priority : bpy.props.IntProperty(options=set())
+    specularity : bpy.props.FloatProperty(name="specularity", options=set())
+    cutoutThresh : bpy.props.IntProperty(name="cutoutThresh", min=0, max=255, default=0, options=set())
+    specMult : bpy.props.FloatProperty(name="spec. mult.", options=set(), default=1.0)
+    emisMult : bpy.props.FloatProperty(name="emis. mult.", options=set(), default=1.0)
+    layerBlendType : bpy.props.EnumProperty(items=matLayerAndEmisBlendModeList, options=set(), default="2")
+    emisBlendType : bpy.props.EnumProperty(items=matLayerAndEmisBlendModeList, options=set(), default="3")
+    specType : bpy.props.EnumProperty(items=matSpecularTypeList, options=set(), default="0")
+    unfogged : bpy.props.BoolProperty(options=set(), default=True)
+    twoSided : bpy.props.BoolProperty(options=set(), default=False)
+    unshaded : bpy.props.BoolProperty(options=set(), default=False)
+    noShadowsCast : bpy.props.BoolProperty(options=set(), default=False)
+    noHitTest : bpy.props.BoolProperty(options=set(), default=False)
+    noShadowsReceived : bpy.props.BoolProperty(options=set(), default=False)
+    depthPrepass : bpy.props.BoolProperty(options=set(), default=False)
+    useTerrainHDR : bpy.props.BoolProperty(options=set(), default=False)
+    splatUVfix : bpy.props.BoolProperty(options=set(), default=False)
+    softBlending : bpy.props.BoolProperty(options=set(), default=False)
+    forParticles : bpy.props.BoolProperty(options=set(), default=False)
+    transparency : bpy.props.BoolProperty(options=set(), default=False)
+    disableSoft : bpy.props.BoolProperty(options=set(), default=False)
+    darkNormalMapping : bpy.props.BoolProperty(options=set(), default=False)
+    decalRequiredOnLowEnd : bpy.props.BoolProperty(options=set(), default=False)
+    acceptSplats : bpy.props.BoolProperty(options=set(), default=False)
+    acceptSplatsOnly : bpy.props.BoolProperty(options=set(), default=False)
+    emissiveRequiredOnLowEnd : bpy.props.BoolProperty(options=set(), default=False)
+    backgroundObject : bpy.props.BoolProperty(options=set(), default=False)
+    zpFillRequiredOnLowEnd : bpy.props.BoolProperty(options=set(), default=False)
+    excludeFromHighlighting : bpy.props.BoolProperty(options=set(), default=False)
+    clampOutput : bpy.props.BoolProperty(options=set(), default=False)
+    geometryVisible : bpy.props.BoolProperty(options=set(), default=True)
     
-    depthBlendFalloff = bpy.props.FloatProperty(name="depth blend falloff", options=set(), update=handleDepthBlendFalloffChanged, default=0.0)
-    useDepthBlendFalloff = bpy.props.BoolProperty(options=set(), update=handleUseDepthBlendFalloffChanged, description="Should be true for particle system materials", default=False)
-    useVertexColor = bpy.props.BoolProperty(options=set(), description="The vertex color layer named color will be used to tint the model", default=False)
-    useVertexAlpha = bpy.props.BoolProperty(options=set(), description="The vertex color layer named alpha, will be used to determine the alpha of the model", default=False)
-    unknownFlag0x200 = bpy.props.BoolProperty(options=set())
+    depthBlendFalloff : bpy.props.FloatProperty(name="depth blend falloff", options=set(), update=handleDepthBlendFalloffChanged, default=0.0)
+    useDepthBlendFalloff : bpy.props.BoolProperty(options=set(), update=handleUseDepthBlendFalloffChanged, description="Should be true for particle system materials", default=False)
+    useVertexColor : bpy.props.BoolProperty(options=set(), description="The vertex color layer named color will be used to tint the model", default=False)
+    useVertexAlpha : bpy.props.BoolProperty(options=set(), description="The vertex color layer named alpha, will be used to determine the alpha of the model", default=False)
+    unknownFlag0x200 : bpy.props.BoolProperty(options=set())
 
 class M3DisplacementMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    strengthFactor = bpy.props.FloatProperty(name="strength factor",options={"ANIMATABLE"}, default=1.0, description="Factor that gets multiplicated with the strength values")
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
-    priority = bpy.props.IntProperty(options=set())
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    strengthFactor : bpy.props.FloatProperty(name="strength factor",options={"ANIMATABLE"}, default=1.0, description="Factor that gets multiplicated with the strength values")
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    priority : bpy.props.IntProperty(options=set())
     
 class M3CompositeMaterialSection(bpy.types.PropertyGroup):
     # The material name is getting called "name" so that blender names it properly in the list view
-    name = bpy.props.StringProperty(options=set()) 
-    alphaFactor = bpy.props.FloatProperty(name="alphaFactor", options={"ANIMATABLE"}, min=0.0, max=1.0, default=1.0, description="Defines the factor with which the alpha channel gets multiplicated")
+    name : bpy.props.StringProperty(options=set()) 
+    alphaFactor : bpy.props.FloatProperty(name="alphaFactor", options={"ANIMATABLE"}, min=0.0, max=1.0, default=1.0, description="Defines the factor with which the alpha channel gets multiplicated")
 
 class M3CompositeMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
-    sections = bpy.props.CollectionProperty(type=M3CompositeMaterialSection, options=set())
-    sectionIndex = bpy.props.IntProperty(options=set(), default=0)
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    sections : bpy.props.CollectionProperty(type=M3CompositeMaterialSection, options=set())
+    sectionIndex : bpy.props.IntProperty(options=set(), default=0)
     
 class M3TerrainMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
 
 class M3VolumeMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    volumeDensity = bpy.props.FloatProperty(name="volume density",options={"ANIMATABLE"}, default=0.3, description="Factor that gets multiplicated with the strength values")
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    volumeDensity : bpy.props.FloatProperty(name="volume density",options={"ANIMATABLE"}, default=0.3, description="Factor that gets multiplicated with the strength values")
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
 
 class M3VolumeNoiseMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    volumeDensity = bpy.props.FloatProperty(name="volume density",options={"ANIMATABLE"}, default=0.3, description="Factor that gets multiplicated with the strength values")
-    nearPlane = bpy.props.FloatProperty(name="near plane",options={"ANIMATABLE"}, default=0.0)
-    falloff = bpy.props.FloatProperty(name="falloff",options={"ANIMATABLE"}, default=0.9)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
-    scrollRate = bpy.props.FloatVectorProperty(name="scroll rate", default=(0.0, 0.0, 0.8), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    translation = bpy.props.FloatVectorProperty(name="translation", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    scale = bpy.props.FloatVectorProperty(name="scale", default=(2.0, 2.0, 1.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    rotation = bpy.props.FloatVectorProperty(name="rotation", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    alphaTreshhold = bpy.props.IntProperty(options=set(), default=0)
-    drawAfterTransparency = bpy.props.BoolProperty(options=set(), default=False)
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    volumeDensity : bpy.props.FloatProperty(name="volume density",options={"ANIMATABLE"}, default=0.3, description="Factor that gets multiplicated with the strength values")
+    nearPlane : bpy.props.FloatProperty(name="near plane",options={"ANIMATABLE"}, default=0.0)
+    falloff : bpy.props.FloatProperty(name="falloff",options={"ANIMATABLE"}, default=0.9)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    scrollRate : bpy.props.FloatVectorProperty(name="scroll rate", default=(0.0, 0.0, 0.8), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    translation : bpy.props.FloatVectorProperty(name="translation", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    scale : bpy.props.FloatVectorProperty(name="scale", default=(2.0, 2.0, 1.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    rotation : bpy.props.FloatVectorProperty(name="rotation", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    alphaTreshhold : bpy.props.IntProperty(options=set(), default=0)
+    drawAfterTransparency : bpy.props.BoolProperty(options=set(), default=False)
 
 class M3CreepMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
 
 class M3STBMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
 
 class M3LensFlareMaterial(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
+    name : bpy.props.StringProperty(name="name", default="Material", update=handleMaterialNameChange, options=set())
     # the following field gets used to update the name of the material reference:
-    materialReferenceIndex = bpy.props.IntProperty(options=set(), default=-1)
-    layers = bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
+    materialReferenceIndex : bpy.props.IntProperty(options=set(), default=-1)
+    layers : bpy.props.CollectionProperty(type=M3MaterialLayer, options=set())
 
 class M3Camera(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="Camera", update=handleCameraNameChange, options=set())
-    oldName = bpy.props.StringProperty(name="oldName", options=set())
-    fieldOfView = bpy.props.FloatProperty(name="fieldOfView", options={"ANIMATABLE"}, default=0.5)
-    farClip = bpy.props.FloatProperty(name="farClip", options={"ANIMATABLE"}, default=10.0)
-    nearClip = bpy.props.FloatProperty(name="nearClip", options={"ANIMATABLE"}, default=10.0)
-    clip2 = bpy.props.FloatProperty(name="clip2", options={"ANIMATABLE"}, default=10.0)
-    focalDepth = bpy.props.FloatProperty(name="focalDepth", options={"ANIMATABLE"}, default=2)
-    falloffStart = bpy.props.FloatProperty(name="falloffStart", options={"ANIMATABLE"}, default=1.0)
-    falloffEnd = bpy.props.FloatProperty(name="falloffEnd", options={"ANIMATABLE"}, default=2.0)
-    depthOfField = bpy.props.FloatProperty(name="depthOfField", options={"ANIMATABLE"}, default=0.5)
+    name : bpy.props.StringProperty(name="name", default="Camera", update=handleCameraNameChange, options=set())
+    oldName : bpy.props.StringProperty(name="oldName", options=set())
+    fieldOfView : bpy.props.FloatProperty(name="fieldOfView", options={"ANIMATABLE"}, default=0.5)
+    farClip : bpy.props.FloatProperty(name="farClip", options={"ANIMATABLE"}, default=10.0)
+    nearClip : bpy.props.FloatProperty(name="nearClip", options={"ANIMATABLE"}, default=10.0)
+    clip2 : bpy.props.FloatProperty(name="clip2", options={"ANIMATABLE"}, default=10.0)
+    focalDepth : bpy.props.FloatProperty(name="focalDepth", options={"ANIMATABLE"}, default=2)
+    falloffStart : bpy.props.FloatProperty(name="falloffStart", options={"ANIMATABLE"}, default=1.0)
+    falloffEnd : bpy.props.FloatProperty(name="falloffEnd", options={"ANIMATABLE"}, default=2.0)
+    depthOfField : bpy.props.FloatProperty(name="depthOfField", options={"ANIMATABLE"}, default=0.5)
 
 class M3Boundings(bpy.types.PropertyGroup):
-    radius = bpy.props.FloatProperty(name="radius", options=set(), default=2.0)
-    center = bpy.props.FloatVectorProperty(name="center", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options=set())
-    size = bpy.props.FloatVectorProperty(name="size", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options=set())
+    radius : bpy.props.FloatProperty(name="radius", options=set(), default=2.0)
+    center : bpy.props.FloatVectorProperty(name="center", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options=set())
+    size : bpy.props.FloatVectorProperty(name="size", default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", options=set())
 
 
 class M3ParticleSpawnPoint(bpy.types.PropertyGroup):
-    location = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), name="location", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first two values are the initial and final size of particles")
+    location : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), name="location", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first two values are the initial and final size of particles")
 
 
 class M3ParticleSystemCopy(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(options=set(), update=handleParticleSystemCopyRename)
-    boneName = bpy.props.StringProperty(options=set())
-    emissionRate = bpy.props.FloatProperty(default=10.0, name="emiss. rate", options={"ANIMATABLE"})
-    partEmit = bpy.props.IntProperty(default=0, subtype="UNSIGNED", options={"ANIMATABLE"})
+    name : bpy.props.StringProperty(options=set(), update=handleParticleSystemCopyRename)
+    boneName : bpy.props.StringProperty(options=set())
+    emissionRate : bpy.props.FloatProperty(default=10.0, name="emiss. rate", options={"ANIMATABLE"})
+    partEmit : bpy.props.IntProperty(default=0, subtype="UNSIGNED", options={"ANIMATABLE"})
 
 
 class M3ParticleSystem(bpy.types.PropertyGroup):
 
     # name attribute seems to be needed for template_list but is not actually in the m3 file
     # The name gets calculated like this: name = boneSuffix (type)
-    name = bpy.props.StringProperty(options=set(), update=handleParticleSystemTypeOrNameChange)
-    boneName = bpy.props.StringProperty(options=set())
-    updateBlenderBoneShapes = bpy.props.BoolProperty(default=True, options=set())
-    materialName = bpy.props.StringProperty(options=set())
-    maxParticles = bpy.props.IntProperty(default=20, subtype="UNSIGNED",options=set())
-    emissionSpeed1 = bpy.props.FloatProperty(name="emis. speed 1",options={"ANIMATABLE"}, default=0.0, description="The initial speed of the particles at emission")
-    emissionSpeed2 = bpy.props.FloatProperty(default=1.0, name="emiss. speed 2",options={"ANIMATABLE"}, description="If emission speed randomization is enabled this value specfies the other end of the range of random speeds")
-    randomizeWithEmissionSpeed2 = bpy.props.BoolProperty(options=set(),default=False, description="Specifies if the second emission speed value should be used to generate random emission speeds")
-    emissionAngleX = bpy.props.FloatProperty(default=0.0, name="emis. angle X", subtype="ANGLE", options={"ANIMATABLE"}, description="Specifies the X rotation of the emission vector")
-    emissionAngleY = bpy.props.FloatProperty(default=0.0, name="emis. angle Y", subtype="ANGLE", options={"ANIMATABLE"}, description="Specifies the Y rotation of the emission vector")
-    emissionSpreadX = bpy.props.FloatProperty(default=0.0, name="emissionSpreadX", options={"ANIMATABLE"}, description="Specifies in radian by how much the emission vector can be randomly rotated around the X axis")
-    emissionSpreadY = bpy.props.FloatProperty(default=0.0, name="emissionSpreadY", options={"ANIMATABLE"}, description="Specifies in radian by how much the emission vector can be randomly rotated around the Y axis")
-    lifespan1 = bpy.props.FloatProperty(default=0.5, name="lifespan1", options={"ANIMATABLE"},  description="Specfies how long it takes before the particles start to decay")
-    lifespan2 = bpy.props.FloatProperty(default=5.0, name="lifespan2", options={"ANIMATABLE"}, description="If random lifespans are enabled this specifies the other end of the range for random lifespan values")
-    randomizeWithLifespan2 = bpy.props.BoolProperty(default=True, name="randomizeWithLifespan2", options=set(), description="Specifies if particles should have random lifespans")
-    zAcceleration = bpy.props.FloatProperty(default=0.0, name="z acceleration",options=set(), description="Negative gravity which does not get influenced by the emission vector")
-    sizeAnimationMiddle = bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="sizeAnimationMiddle", options=set(), description="Percentage of lifetime when the scale animation reaches reaches its middle value")
-    colorAnimationMiddle = bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="colorAnimationMiddle", options=set(), description="Percentage of lifetime when the color animation (without alpha) reaches reaches its middle value")
-    alphaAnimationMiddle = bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="alphaAnimationMiddle", options=set(), description="Percentage of lifetime when the alpha animation reaches reaches its middle value")
-    rotationAnimationMiddle = bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="rotationAnimationMiddle", options=set(), description="Percentage of lifetime when the scale animation reaches reaches its middle value")
-    sizeHoldTime = bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="sizeHoldTime", options=set(), description="Factor of particle liftime to hold the middle size value")
-    colorHoldTime = bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="colorHoldTime", options=set(), description="Factor of particle lifetime to hold the middle color and alpha value")
-    alphaHoldTime = bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="alphaHoldTime", options=set(), description="Factor of particle lifetime to hold the middle rotation value")    
-    rotationHoldTime = bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="rotationHoldTime", options=set(), description="Factor of particle lifetime to hold the middle rotation value")    
-    sizeSmoothingType = bpy.props.EnumProperty(default="0", items=particleAnimationSmoothTypeList, options=set(), description="Determines the shape of the size curve based on the intial, middle , final and hold time value")    
-    colorSmoothingType = bpy.props.EnumProperty(default="0", items=particleAnimationSmoothTypeList, options=set(), description="Determines the shape of the color curve based on the intial, middle , final and hold time value")    
-    rotationSmoothingType = bpy.props.EnumProperty(default="0", items=particleAnimationSmoothTypeList, options=set(), description="Determines the shape of the rotation curve based on the intial, middle , final and hold time value")    
-    particleSizes1 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), name="particle sizes 1", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first two values are the initial and final size of particles")
-    rotationValues1 = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), name="rotation values 1", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first value is the inital rotation and the second value is the rotation speed")
-    initialColor1 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="initial color 1", size=4, subtype="COLOR", options={"ANIMATABLE"}, description="Color of the particle when it gets emitted")
-    middleColor1 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="unknown color 1", size=4, subtype="COLOR", options={"ANIMATABLE"})
-    finalColor1 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 0.5), min = 0.0, max = 1.0, name="final color 1", size=4, subtype="COLOR", options={"ANIMATABLE"}, description="The color the particle will have when it vanishes")
-    slowdown = bpy.props.FloatProperty(default=1.0, min=0.0, name="slowdown" ,options=set(), description="The amounth of speed reduction in the particles lifetime")
-    mass = bpy.props.FloatProperty(default=0.001, name="mass",options=set())
-    mass2 = bpy.props.FloatProperty(default=1.0, name="mass2",options=set())
-    randomizeWithMass2 = bpy.props.BoolProperty(options=set(),default=True, description="Specifies if the second mass value should be used to generate random mass values")
-    unknownFloat2c = bpy.props.FloatProperty(default=2.0, name="unknownFloat2c",options=set())
-    trailingEnabled = bpy.props.BoolProperty(default=True, options=set(), description="If trailing is enabled then particles don't follow the particle emitter")
-    emissionRate = bpy.props.FloatProperty(default=10.0, name="emiss. rate", options={"ANIMATABLE"})
-    emissionAreaType = bpy.props.EnumProperty(default="2", items=emissionAreaTypeList, update=handleParticleSystemTypeOrNameChange, options=set())
-    cutoutEmissionArea = bpy.props.BoolProperty(options=set())
-    emissionAreaSize = bpy.props.FloatVectorProperty(default=(0.1, 0.1, 0.1), name="emis. area size", update=handleParticleSystemAreaSizeChange, size=3, subtype="XYZ", options={"ANIMATABLE"})
-    emissionAreaCutoutSize = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), name="tail unk.", size=3, subtype="XYZ", options={"ANIMATABLE"})
-    emissionAreaRadius = bpy.props.FloatProperty(default=2.0, name="emis. area radius", update=handleParticleSystemAreaSizeChange, options={"ANIMATABLE"})
-    emissionAreaCutoutRadius = bpy.props.FloatProperty(default=0.0, name="spread unk.", options={"ANIMATABLE"})
-    spawnPoints = bpy.props.CollectionProperty(type=M3ParticleSpawnPoint)
-    emissionType = bpy.props.EnumProperty(default="0", items=particleEmissionTypeList, options=set())
-    randomizeWithParticleSizes2 = bpy.props.BoolProperty(default=False, options=set(), description="Specifies if particles have random sizes")
-    particleSizes2 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), name="particle sizes 2", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first two values are used to determine a random initial and final size for a particle")
-    randomizeWithRotationValues2 = bpy.props.BoolProperty(default=False, options=set())
-    rotationValues2 = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), name="rotation values 2", size=3, subtype="XYZ", options={"ANIMATABLE"})
-    randomizeWithColor2 = bpy.props.BoolProperty(default=False, options=set())
-    initialColor2 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="initial color 2", size=4, subtype="COLOR", options={"ANIMATABLE"})
-    middleColor2 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="unknown color 2", size=4, subtype="COLOR", options={"ANIMATABLE"})
-    finalColor2 = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 0.0), min = 0.0, max = 1.0, name="final color 2", size=4, subtype="COLOR", options={"ANIMATABLE"})
-    partEmit = bpy.props.IntProperty(default=0, subtype="UNSIGNED", options={"ANIMATABLE"})
-    phase1StartImageIndex = bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at start of phase 1 when the image got divided into rows and collumns")
-    phase1EndImageIndex = bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at end of phase 1 when the image got divided into rows and collumns")
-    phase2StartImageIndex = bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at start of phase 2 when the image got divided into rows and collumns")
-    phase2EndImageIndex = bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at end of phase 2 when the image got divided into rows and collumns")
-    relativePhase1Length = bpy.props.FloatProperty(default=1.0, min=0.0, max=1.0, subtype="FACTOR", name="relative phase 1 length", options=set(), description="A value of 0.4 means that 40% of the lifetime of the particle the phase 1 image animation will play")
-    numberOfColumns = bpy.props.IntProperty(default=0, min=0, subtype="UNSIGNED", name="columns", options=set(), description="Specifies in how many columns the image gets divided")
-    numberOfRows = bpy.props.IntProperty(default=0, min=0, subtype="UNSIGNED", name="rows", options=set(), description="Specifies in how many rows the image gets divided")
-    columnWidth = bpy.props.FloatProperty(default=float("inf"), min=0.0, max=1.0, name="columnWidth", options=set(), description="Specifies the width of one column, relative to an image with width 1")
-    rowHeight = bpy.props.FloatProperty(default=float("inf"), min=0.0, max=1.0, name="rowHeight", options=set(), description="Specifies the height of one row, relative to an image with height 1")
-    unknownFloat4 = bpy.props.FloatProperty(default=0.0, name="unknownFloat4",options=set())
-    unknownFloat5 = bpy.props.FloatProperty(default=1.0, name="unknownFloat5",options=set())
-    unknownFloat6 = bpy.props.FloatProperty(default=1.0, name="unknownFloat6",options=set())
-    unknownFloat7 = bpy.props.FloatProperty(default=1.0, name="unknownFloat7",options=set())
-    particleType = bpy.props.EnumProperty(default="0", items=particleTypeList, options=set())
-    lengthWidthRatio = bpy.props.FloatProperty(default=1.0, name="lengthWidthRatio",options=set())
-    localForceChannels = bpy.props.BoolVectorProperty(default=tuple(16*[False]), size=16, subtype="LAYER", options=set(), description="If a model internal force shares a local force channel with a particle system then it affects it")
-    worldForceChannels = bpy.props.BoolVectorProperty(default=tuple(16*[False]), size=16, subtype="LAYER", options=set(), description="If a force shares a force channel with a particle system then it affects it")
-    copies = bpy.props.CollectionProperty(type=M3ParticleSystemCopy)
-    copyIndex = bpy.props.IntProperty(options=set(), update=handlePartileSystemCopyIndexChanged)
-    trailingParticlesName = bpy.props.StringProperty(options=set())
-    trailingParticlesChance = bpy.props.FloatProperty(default=0.0, min=0.0, max=1.0, subtype="FACTOR", name="trailingParticlesChance",options=set())
-    trailingParticlesRate = bpy.props.FloatProperty(default=10.0, name="trail. emiss. rate", options={"ANIMATABLE"})
-    noiseAmplitude = bpy.props.FloatProperty(default=0.0, name="noiseAmplitude",options=set())
-    noiseFrequency = bpy.props.FloatProperty(default=0.0, name="noiseFrequency",options=set())
-    noiseCohesion = bpy.props.FloatProperty(default=0.0, name="noiseCohesion",options=set(), description="Prevents the particles from spreading to far from noise")
-    noiseEdge = bpy.props.FloatProperty(default=0.0, min=0.0, max=0.5, subtype="FACTOR", name="noiseEdge", options=set(), description="The closer the value is to 0.5 the less noise will be at the start of particles life time")
-    sort = bpy.props.BoolProperty(options=set())
-    collideTerrain = bpy.props.BoolProperty(options=set())
-    collideObjects = bpy.props.BoolProperty(options=set())
-    spawnOnBounce = bpy.props.BoolProperty(options=set())
-    inheritEmissionParams = bpy.props.BoolProperty(options=set())
-    inheritParentVel = bpy.props.BoolProperty(options=set())
-    sortByZHeight = bpy.props.BoolProperty(options=set())
-    reverseIteration = bpy.props.BoolProperty(options=set())
-    litParts = bpy.props.BoolProperty(options=set())
-    randFlipBookStart = bpy.props.BoolProperty(options=set())
-    multiplyByGravity = bpy.props.BoolProperty(options=set())
-    clampTailParts = bpy.props.BoolProperty(options=set())
-    spawnTrailingParts = bpy.props.BoolProperty(options=set())
-    fixLengthTailParts = bpy.props.BoolProperty(options=set())
-    useVertexAlpha = bpy.props.BoolProperty(options=set())
-    modelParts = bpy.props.BoolProperty(options=set())
-    swapYZonModelParts = bpy.props.BoolProperty(options=set())
-    scaleTimeByParent = bpy.props.BoolProperty(options=set())
-    useLocalTime = bpy.props.BoolProperty(options=set())
-    simulateOnInit = bpy.props.BoolProperty(options=set())
-    copy = bpy.props.BoolProperty(options=set())
+    name : bpy.props.StringProperty(options=set(), update=handleParticleSystemTypeOrNameChange)
+    boneName : bpy.props.StringProperty(options=set())
+    updateBlenderBoneShapes : bpy.props.BoolProperty(default=True, options=set())
+    materialName : bpy.props.StringProperty(options=set())
+    maxParticles : bpy.props.IntProperty(default=20, subtype="UNSIGNED",options=set())
+    emissionSpeed1 : bpy.props.FloatProperty(name="emis. speed 1",options={"ANIMATABLE"}, default=0.0, description="The initial speed of the particles at emission")
+    emissionSpeed2 : bpy.props.FloatProperty(default=1.0, name="emiss. speed 2",options={"ANIMATABLE"}, description="If emission speed randomization is enabled this value specfies the other end of the range of random speeds")
+    randomizeWithEmissionSpeed2 : bpy.props.BoolProperty(options=set(),default=False, description="Specifies if the second emission speed value should be used to generate random emission speeds")
+    emissionAngleX : bpy.props.FloatProperty(default=0.0, name="emis. angle X", subtype="ANGLE", options={"ANIMATABLE"}, description="Specifies the X rotation of the emission vector")
+    emissionAngleY : bpy.props.FloatProperty(default=0.0, name="emis. angle Y", subtype="ANGLE", options={"ANIMATABLE"}, description="Specifies the Y rotation of the emission vector")
+    emissionSpreadX : bpy.props.FloatProperty(default=0.0, name="emissionSpreadX", options={"ANIMATABLE"}, description="Specifies in radian by how much the emission vector can be randomly rotated around the X axis")
+    emissionSpreadY : bpy.props.FloatProperty(default=0.0, name="emissionSpreadY", options={"ANIMATABLE"}, description="Specifies in radian by how much the emission vector can be randomly rotated around the Y axis")
+    lifespan1 : bpy.props.FloatProperty(default=0.5, name="lifespan1", options={"ANIMATABLE"},  description="Specfies how long it takes before the particles start to decay")
+    lifespan2 : bpy.props.FloatProperty(default=5.0, name="lifespan2", options={"ANIMATABLE"}, description="If random lifespans are enabled this specifies the other end of the range for random lifespan values")
+    randomizeWithLifespan2 : bpy.props.BoolProperty(default=True, name="randomizeWithLifespan2", options=set(), description="Specifies if particles should have random lifespans")
+    zAcceleration : bpy.props.FloatProperty(default=0.0, name="z acceleration",options=set(), description="Negative gravity which does not get influenced by the emission vector")
+    sizeAnimationMiddle : bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="sizeAnimationMiddle", options=set(), description="Percentage of lifetime when the scale animation reaches reaches its middle value")
+    colorAnimationMiddle : bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="colorAnimationMiddle", options=set(), description="Percentage of lifetime when the color animation (without alpha) reaches reaches its middle value")
+    alphaAnimationMiddle : bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="alphaAnimationMiddle", options=set(), description="Percentage of lifetime when the alpha animation reaches reaches its middle value")
+    rotationAnimationMiddle : bpy.props.FloatProperty(default=0.5, min=0.0, max=1.0, subtype="FACTOR", name="rotationAnimationMiddle", options=set(), description="Percentage of lifetime when the scale animation reaches reaches its middle value")
+    sizeHoldTime : bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="sizeHoldTime", options=set(), description="Factor of particle liftime to hold the middle size value")
+    colorHoldTime : bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="colorHoldTime", options=set(), description="Factor of particle lifetime to hold the middle color and alpha value")
+    alphaHoldTime : bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="alphaHoldTime", options=set(), description="Factor of particle lifetime to hold the middle rotation value")    
+    rotationHoldTime : bpy.props.FloatProperty(default=0.3, min=0.0, max=1.0, name="rotationHoldTime", options=set(), description="Factor of particle lifetime to hold the middle rotation value")    
+    sizeSmoothingType : bpy.props.EnumProperty(default="0", items=particleAnimationSmoothTypeList, options=set(), description="Determines the shape of the size curve based on the intial, middle , final and hold time value")    
+    colorSmoothingType : bpy.props.EnumProperty(default="0", items=particleAnimationSmoothTypeList, options=set(), description="Determines the shape of the color curve based on the intial, middle , final and hold time value")    
+    rotationSmoothingType : bpy.props.EnumProperty(default="0", items=particleAnimationSmoothTypeList, options=set(), description="Determines the shape of the rotation curve based on the intial, middle , final and hold time value")    
+    particleSizes1 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), name="particle sizes 1", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first two values are the initial and final size of particles")
+    rotationValues1 : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), name="rotation values 1", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first value is the inital rotation and the second value is the rotation speed")
+    initialColor1 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="initial color 1", size=4, subtype="COLOR", options={"ANIMATABLE"}, description="Color of the particle when it gets emitted")
+    middleColor1 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="unknown color 1", size=4, subtype="COLOR", options={"ANIMATABLE"})
+    finalColor1 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 0.5), min = 0.0, max = 1.0, name="final color 1", size=4, subtype="COLOR", options={"ANIMATABLE"}, description="The color the particle will have when it vanishes")
+    slowdown : bpy.props.FloatProperty(default=1.0, min=0.0, name="slowdown" ,options=set(), description="The amounth of speed reduction in the particles lifetime")
+    mass : bpy.props.FloatProperty(default=0.001, name="mass",options=set())
+    mass2 : bpy.props.FloatProperty(default=1.0, name="mass2",options=set())
+    randomizeWithMass2 : bpy.props.BoolProperty(options=set(),default=True, description="Specifies if the second mass value should be used to generate random mass values")
+    unknownFloat2c : bpy.props.FloatProperty(default=2.0, name="unknownFloat2c",options=set())
+    trailingEnabled : bpy.props.BoolProperty(default=True, options=set(), description="If trailing is enabled then particles don't follow the particle emitter")
+    emissionRate : bpy.props.FloatProperty(default=10.0, name="emiss. rate", options={"ANIMATABLE"})
+    emissionAreaType : bpy.props.EnumProperty(default="2", items=emissionAreaTypeList, update=handleParticleSystemTypeOrNameChange, options=set())
+    cutoutEmissionArea : bpy.props.BoolProperty(options=set())
+    emissionAreaSize : bpy.props.FloatVectorProperty(default=(0.1, 0.1, 0.1), name="emis. area size", update=handleParticleSystemAreaSizeChange, size=3, subtype="XYZ", options={"ANIMATABLE"})
+    emissionAreaCutoutSize : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), name="tail unk.", size=3, subtype="XYZ", options={"ANIMATABLE"})
+    emissionAreaRadius : bpy.props.FloatProperty(default=2.0, name="emis. area radius", update=handleParticleSystemAreaSizeChange, options={"ANIMATABLE"})
+    emissionAreaCutoutRadius : bpy.props.FloatProperty(default=0.0, name="spread unk.", options={"ANIMATABLE"})
+    spawnPoints : bpy.props.CollectionProperty(type=M3ParticleSpawnPoint)
+    emissionType : bpy.props.EnumProperty(default="0", items=particleEmissionTypeList, options=set())
+    randomizeWithParticleSizes2 : bpy.props.BoolProperty(default=False, options=set(), description="Specifies if particles have random sizes")
+    particleSizes2 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), name="particle sizes 2", size=3, subtype="XYZ", options={"ANIMATABLE"}, description="The first two values are used to determine a random initial and final size for a particle")
+    randomizeWithRotationValues2 : bpy.props.BoolProperty(default=False, options=set())
+    rotationValues2 : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), name="rotation values 2", size=3, subtype="XYZ", options={"ANIMATABLE"})
+    randomizeWithColor2 : bpy.props.BoolProperty(default=False, options=set())
+    initialColor2 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="initial color 2", size=4, subtype="COLOR", options={"ANIMATABLE"})
+    middleColor2 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, name="unknown color 2", size=4, subtype="COLOR", options={"ANIMATABLE"})
+    finalColor2 : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0, 0.0), min = 0.0, max = 1.0, name="final color 2", size=4, subtype="COLOR", options={"ANIMATABLE"})
+    partEmit : bpy.props.IntProperty(default=0, subtype="UNSIGNED", options={"ANIMATABLE"})
+    phase1StartImageIndex : bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at start of phase 1 when the image got divided into rows and collumns")
+    phase1EndImageIndex : bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at end of phase 1 when the image got divided into rows and collumns")
+    phase2StartImageIndex : bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at start of phase 2 when the image got divided into rows and collumns")
+    phase2EndImageIndex : bpy.props.IntProperty(default=0, min=0, max=255, subtype="UNSIGNED", options=set(), description="Specifies the cell index shown at end of phase 2 when the image got divided into rows and collumns")
+    relativePhase1Length : bpy.props.FloatProperty(default=1.0, min=0.0, max=1.0, subtype="FACTOR", name="relative phase 1 length", options=set(), description="A value of 0.4 means that 40% of the lifetime of the particle the phase 1 image animation will play")
+    numberOfColumns : bpy.props.IntProperty(default=0, min=0, subtype="UNSIGNED", name="columns", options=set(), description="Specifies in how many columns the image gets divided")
+    numberOfRows : bpy.props.IntProperty(default=0, min=0, subtype="UNSIGNED", name="rows", options=set(), description="Specifies in how many rows the image gets divided")
+    columnWidth : bpy.props.FloatProperty(default=float("inf"), min=0.0, max=1.0, name="columnWidth", options=set(), description="Specifies the width of one column, relative to an image with width 1")
+    rowHeight : bpy.props.FloatProperty(default=float("inf"), min=0.0, max=1.0, name="rowHeight", options=set(), description="Specifies the height of one row, relative to an image with height 1")
+    unknownFloat4 : bpy.props.FloatProperty(default=0.0, name="unknownFloat4",options=set())
+    unknownFloat5 : bpy.props.FloatProperty(default=1.0, name="unknownFloat5",options=set())
+    unknownFloat6 : bpy.props.FloatProperty(default=1.0, name="unknownFloat6",options=set())
+    unknownFloat7 : bpy.props.FloatProperty(default=1.0, name="unknownFloat7",options=set())
+    particleType : bpy.props.EnumProperty(default="0", items=particleTypeList, options=set())
+    lengthWidthRatio : bpy.props.FloatProperty(default=1.0, name="lengthWidthRatio",options=set())
+    localForceChannels : bpy.props.BoolVectorProperty(default=tuple(16*[False]), size=16, subtype="LAYER", options=set(), description="If a model internal force shares a local force channel with a particle system then it affects it")
+    worldForceChannels : bpy.props.BoolVectorProperty(default=tuple(16*[False]), size=16, subtype="LAYER", options=set(), description="If a force shares a force channel with a particle system then it affects it")
+    copies : bpy.props.CollectionProperty(type=M3ParticleSystemCopy)
+    copyIndex : bpy.props.IntProperty(options=set(), update=handlePartileSystemCopyIndexChanged)
+    trailingParticlesName : bpy.props.StringProperty(options=set())
+    trailingParticlesChance : bpy.props.FloatProperty(default=0.0, min=0.0, max=1.0, subtype="FACTOR", name="trailingParticlesChance",options=set())
+    trailingParticlesRate : bpy.props.FloatProperty(default=10.0, name="trail. emiss. rate", options={"ANIMATABLE"})
+    noiseAmplitude : bpy.props.FloatProperty(default=0.0, name="noiseAmplitude",options=set())
+    noiseFrequency : bpy.props.FloatProperty(default=0.0, name="noiseFrequency",options=set())
+    noiseCohesion : bpy.props.FloatProperty(default=0.0, name="noiseCohesion",options=set(), description="Prevents the particles from spreading to far from noise")
+    noiseEdge : bpy.props.FloatProperty(default=0.0, min=0.0, max=0.5, subtype="FACTOR", name="noiseEdge", options=set(), description="The closer the value is to 0.5 the less noise will be at the start of particles life time")
+    sort : bpy.props.BoolProperty(options=set())
+    collideTerrain : bpy.props.BoolProperty(options=set())
+    collideObjects : bpy.props.BoolProperty(options=set())
+    spawnOnBounce : bpy.props.BoolProperty(options=set())
+    inheritEmissionParams : bpy.props.BoolProperty(options=set())
+    inheritParentVel : bpy.props.BoolProperty(options=set())
+    sortByZHeight : bpy.props.BoolProperty(options=set())
+    reverseIteration : bpy.props.BoolProperty(options=set())
+    litParts : bpy.props.BoolProperty(options=set())
+    randFlipBookStart : bpy.props.BoolProperty(options=set())
+    multiplyByGravity : bpy.props.BoolProperty(options=set())
+    clampTailParts : bpy.props.BoolProperty(options=set())
+    spawnTrailingParts : bpy.props.BoolProperty(options=set())
+    fixLengthTailParts : bpy.props.BoolProperty(options=set())
+    useVertexAlpha : bpy.props.BoolProperty(options=set())
+    modelParts : bpy.props.BoolProperty(options=set())
+    swapYZonModelParts : bpy.props.BoolProperty(options=set())
+    scaleTimeByParent : bpy.props.BoolProperty(options=set())
+    useLocalTime : bpy.props.BoolProperty(options=set())
+    simulateOnInit : bpy.props.BoolProperty(options=set())
+    copy : bpy.props.BoolProperty(options=set())
 
 class M3RibbonEndPoint(bpy.types.PropertyGroup):
     # nane is also bone name
-    name = bpy.props.StringProperty(options=set())
+    name : bpy.props.StringProperty(options=set())
     
 
 class M3Ribbon(bpy.types.PropertyGroup):
     # name attribute seems to be needed for template_list but is not actually in the m3 file
     # The name gets calculated like this: name = boneSuffix (type)
-    name = bpy.props.StringProperty(options=set())
-    boneSuffix = bpy.props.StringProperty(options=set(), update=handleRibbonBoneSuffixChange, default="Particle System")
-    boneName = bpy.props.StringProperty(options=set())
-    updateBlenderBoneShapes = bpy.props.BoolProperty(default=True, options=set())
-    materialName = bpy.props.StringProperty(options=set())
-    waveLength = bpy.props.FloatProperty(default=1.0, name="waveLength", options={"ANIMATABLE"})
-    tipOffsetZ = bpy.props.FloatProperty(default=0.0, name="tipOffsetZ", options=set())
-    centerBias = bpy.props.FloatProperty(default=0.5, name="centerBias", options=set())
-    radiusScale =  bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
-    twist = bpy.props.FloatProperty(default=0.0, name="twist", options=set())
-    baseColoring = bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
-    centerColoring = bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
-    tipColoring = bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
-    stretchAmount = bpy.props.FloatProperty(default=1.0, name="stretchAmount", options=set())
-    stretchLimit = bpy.props.FloatProperty(default=1.0, name="stretchLimit", options=set())
-    surfaceNoiseAmplitude = bpy.props.FloatProperty(default=0.0, name="surfaceNoiseAmplitude", options=set())
-    surfaceNoiseNumberOfWaves = bpy.props.FloatProperty(default=0.0, name="surfaceNoiseNumberOfWaves", options=set())
-    surfaceNoiseFrequency = bpy.props.FloatProperty(default=0.0, name="surfaceNoiseFrequency", options=set())
-    surfaceNoiseScale = bpy.props.FloatProperty(default=0.2, name="surfaceNoiseScale", options=set())
-    ribbonType = bpy.props.EnumProperty(default="0", items=ribbonTypeList, options=set())
-    ribbonDivisions = bpy.props.FloatProperty(default=20.0, name="ribbonDivisions", options=set())
-    ribbonSides = bpy.props.IntProperty(default=5, subtype="UNSIGNED",options=set())
-    ribbonLength = bpy.props.FloatProperty(default=1.0, name="ribbonLength", options={"ANIMATABLE"})
-    directionVariationBool = bpy.props.BoolProperty(default=False, options=set())
-    directionVariationAmount = bpy.props.FloatProperty(default=0.0, name="directionVariationAmount", options={"ANIMATABLE"})
-    directionVariationFrequency = bpy.props.FloatProperty(default=0.0, name="directionVariationFrequency", options={"ANIMATABLE"})
-    amplitudeVariationBool = bpy.props.BoolProperty(default=False, options=set())
-    amplitudeVariationAmount = bpy.props.FloatProperty(default=0.0, name="amplitudeVariationAmount", options={"ANIMATABLE"})
-    amplitudeVariationFrequency = bpy.props.FloatProperty(default=0.0, name="amplitudeVariationFrequency", options={"ANIMATABLE"})
-    lengthVariationBool = bpy.props.BoolProperty(default=False, options=set())
-    lengthVariationAmount = bpy.props.FloatProperty(default=0.0, name="lengthVariationAmount", options={"ANIMATABLE"})
-    lengthVariationFrequency = bpy.props.FloatProperty(default=0.0, name="lengthVariationFrequency", options={"ANIMATABLE"})
-    radiusVariationBool = bpy.props.BoolProperty(default=False, options=set())
-    radiusVariationAmount = bpy.props.FloatProperty(default=0.0, name="radiusVariationAmount", options={"ANIMATABLE"})
-    radiusVariationFrequency = bpy.props.FloatProperty(default=0.0, name="radiusVariationFrequency", options={"ANIMATABLE"})
-    collideWithTerrain = bpy.props.BoolProperty(default=False, options=set())
-    collideWithObjects = bpy.props.BoolProperty(default=False, options=set())
-    edgeFalloff = bpy.props.BoolProperty(default=False, options=set())
-    inheritParentVelocity = bpy.props.BoolProperty(default=False, options=set())
-    smoothSize = bpy.props.BoolProperty(default=False, options=set())
-    bezierSmoothSize = bpy.props.BoolProperty(default=False, options=set())
-    useVertexAlpha = bpy.props.BoolProperty(default=False, options=set())
-    scaleTimeByParent = bpy.props.BoolProperty(default=False, options=set())
-    forceLegacy = bpy.props.BoolProperty(default=False, options=set())
-    useLocaleTime = bpy.props.BoolProperty(default=False, options=set())
-    simulateOnInitialization = bpy.props.BoolProperty(default=False, options=set())
-    useLengthAndTime = bpy.props.BoolProperty(default=False, options=set())
-    endPoints = bpy.props.CollectionProperty(type=M3RibbonEndPoint)
-    endPointIndex = bpy.props.IntProperty(default=-1, options=set(), update=handleRibbonEndPointIndexChanged)
+    name : bpy.props.StringProperty(options=set())
+    boneSuffix : bpy.props.StringProperty(options=set(), update=handleRibbonBoneSuffixChange, default="Particle System")
+    boneName : bpy.props.StringProperty(options=set())
+    updateBlenderBoneShapes : bpy.props.BoolProperty(default=True, options=set())
+    materialName : bpy.props.StringProperty(options=set())
+    waveLength : bpy.props.FloatProperty(default=1.0, name="waveLength", options={"ANIMATABLE"})
+    tipOffsetZ : bpy.props.FloatProperty(default=0.0, name="tipOffsetZ", options=set())
+    centerBias : bpy.props.FloatProperty(default=0.5, name="centerBias", options=set())
+    radiusScale : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", options={"ANIMATABLE"})
+    twist : bpy.props.FloatProperty(default=0.0, name="twist", options=set())
+    baseColoring : bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
+    centerColoring : bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
+    tipColoring : bpy.props.FloatVectorProperty(name="color", default=(1.0, 1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=4, subtype="COLOR", options={"ANIMATABLE"})
+    stretchAmount : bpy.props.FloatProperty(default=1.0, name="stretchAmount", options=set())
+    stretchLimit : bpy.props.FloatProperty(default=1.0, name="stretchLimit", options=set())
+    surfaceNoiseAmplitude : bpy.props.FloatProperty(default=0.0, name="surfaceNoiseAmplitude", options=set())
+    surfaceNoiseNumberOfWaves : bpy.props.FloatProperty(default=0.0, name="surfaceNoiseNumberOfWaves", options=set())
+    surfaceNoiseFrequency : bpy.props.FloatProperty(default=0.0, name="surfaceNoiseFrequency", options=set())
+    surfaceNoiseScale : bpy.props.FloatProperty(default=0.2, name="surfaceNoiseScale", options=set())
+    ribbonType : bpy.props.EnumProperty(default="0", items=ribbonTypeList, options=set())
+    ribbonDivisions : bpy.props.FloatProperty(default=20.0, name="ribbonDivisions", options=set())
+    ribbonSides : bpy.props.IntProperty(default=5, subtype="UNSIGNED",options=set())
+    ribbonLength : bpy.props.FloatProperty(default=1.0, name="ribbonLength", options={"ANIMATABLE"})
+    directionVariationBool : bpy.props.BoolProperty(default=False, options=set())
+    directionVariationAmount : bpy.props.FloatProperty(default=0.0, name="directionVariationAmount", options={"ANIMATABLE"})
+    directionVariationFrequency : bpy.props.FloatProperty(default=0.0, name="directionVariationFrequency", options={"ANIMATABLE"})
+    amplitudeVariationBool : bpy.props.BoolProperty(default=False, options=set())
+    amplitudeVariationAmount : bpy.props.FloatProperty(default=0.0, name="amplitudeVariationAmount", options={"ANIMATABLE"})
+    amplitudeVariationFrequency : bpy.props.FloatProperty(default=0.0, name="amplitudeVariationFrequency", options={"ANIMATABLE"})
+    lengthVariationBool : bpy.props.BoolProperty(default=False, options=set())
+    lengthVariationAmount : bpy.props.FloatProperty(default=0.0, name="lengthVariationAmount", options={"ANIMATABLE"})
+    lengthVariationFrequency : bpy.props.FloatProperty(default=0.0, name="lengthVariationFrequency", options={"ANIMATABLE"})
+    radiusVariationBool : bpy.props.BoolProperty(default=False, options=set())
+    radiusVariationAmount : bpy.props.FloatProperty(default=0.0, name="radiusVariationAmount", options={"ANIMATABLE"})
+    radiusVariationFrequency : bpy.props.FloatProperty(default=0.0, name="radiusVariationFrequency", options={"ANIMATABLE"})
+    collideWithTerrain : bpy.props.BoolProperty(default=False, options=set())
+    collideWithObjects : bpy.props.BoolProperty(default=False, options=set())
+    edgeFalloff : bpy.props.BoolProperty(default=False, options=set())
+    inheritParentVelocity : bpy.props.BoolProperty(default=False, options=set())
+    smoothSize : bpy.props.BoolProperty(default=False, options=set())
+    bezierSmoothSize : bpy.props.BoolProperty(default=False, options=set())
+    useVertexAlpha : bpy.props.BoolProperty(default=False, options=set())
+    scaleTimeByParent : bpy.props.BoolProperty(default=False, options=set())
+    forceLegacy : bpy.props.BoolProperty(default=False, options=set())
+    useLocaleTime : bpy.props.BoolProperty(default=False, options=set())
+    simulateOnInitialization : bpy.props.BoolProperty(default=False, options=set())
+    useLengthAndTime : bpy.props.BoolProperty(default=False, options=set())
+    endPoints : bpy.props.CollectionProperty(type=M3RibbonEndPoint)
+    endPointIndex : bpy.props.IntProperty(default=-1, options=set(), update=handleRibbonEndPointIndexChanged)
 
 
 class M3Force(bpy.types.PropertyGroup):
     # name attribute seems to be needed for template_list but is not actually in the m3 file
     # The name gets calculated like this: name = boneSuffix (type)
-    name = bpy.props.StringProperty(options=set())
-    updateBlenderBoneShape = bpy.props.BoolProperty(default=True, options=set())
-    boneSuffix = bpy.props.StringProperty(options=set(), update=handleForceTypeOrBoneSuffixChange, default="Particle System")
-    boneName = bpy.props.StringProperty(options=set())
-    type = bpy.props.EnumProperty(default="0", items=forceTypeList, update=handleForceTypeOrBoneSuffixChange, options=set())
-    shape = bpy.props.EnumProperty(default="0", items=forceShapeList, update=handleForceTypeOrBoneSuffixChange, options=set())
-    channels = bpy.props.BoolVectorProperty(default=tuple(32*[False]), size=32, subtype="LAYER", options=set(), description="If a force shares a force channel with a particle system then it affects it")
-    strength = bpy.props.FloatProperty(default=1.0, name="Strength", options={"ANIMATABLE"})
-    width = bpy.props.FloatProperty(default=1.0, name="Radius/Width", update=handleForceRangeUpdate, options={"ANIMATABLE"})
-    height = bpy.props.FloatProperty(default=0.05, name="Height/Angle", options={"ANIMATABLE"})
-    length = bpy.props.FloatProperty(default=0.05, name="Length", options={"ANIMATABLE"})
-    useFalloff = bpy.props.BoolProperty(options=set())
-    useHeightGradient = bpy.props.BoolProperty(options=set())
-    unbounded = bpy.props.BoolProperty(options=set())
+    name : bpy.props.StringProperty(options=set())
+    updateBlenderBoneShape : bpy.props.BoolProperty(default=True, options=set())
+    boneSuffix : bpy.props.StringProperty(options=set(), update=handleForceTypeOrBoneSuffixChange, default="Particle System")
+    boneName : bpy.props.StringProperty(options=set())
+    type : bpy.props.EnumProperty(default="0", items=forceTypeList, update=handleForceTypeOrBoneSuffixChange, options=set())
+    shape : bpy.props.EnumProperty(default="0", items=forceShapeList, update=handleForceTypeOrBoneSuffixChange, options=set())
+    channels : bpy.props.BoolVectorProperty(default=tuple(32*[False]), size=32, subtype="LAYER", options=set(), description="If a force shares a force channel with a particle system then it affects it")
+    strength : bpy.props.FloatProperty(default=1.0, name="Strength", options={"ANIMATABLE"})
+    width : bpy.props.FloatProperty(default=1.0, name="Radius/Width", update=handleForceRangeUpdate, options={"ANIMATABLE"})
+    height : bpy.props.FloatProperty(default=0.05, name="Height/Angle", options={"ANIMATABLE"})
+    length : bpy.props.FloatProperty(default=0.05, name="Length", options={"ANIMATABLE"})
+    useFalloff : bpy.props.BoolProperty(options=set())
+    useHeightGradient : bpy.props.BoolProperty(options=set())
+    unbounded : bpy.props.BoolProperty(options=set())
 
 class M3PhysicsShape(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(options=set())
-    updateBlenderBoneShapes = bpy.props.BoolProperty(default=True, options=set())
-    offset = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", update=handlePhysicsShapeUpdate)
-    rotationEuler = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="EULER", unit="ROTATION", update=handlePhysicsShapeUpdate)
-    scale = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", update=handlePhysicsShapeUpdate)
-    shape = bpy.props.EnumProperty(default="0", items=physicsShapeTypeList, update=handlePhysicsShapeUpdate, options=set())
-    meshObjectName = bpy.props.StringProperty(name="meshName", options=set())
+    name : bpy.props.StringProperty(options=set())
+    updateBlenderBoneShapes : bpy.props.BoolProperty(default=True, options=set())
+    offset : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", update=handlePhysicsShapeUpdate)
+    rotationEuler : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="EULER", unit="ROTATION", update=handlePhysicsShapeUpdate)
+    scale : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", update=handlePhysicsShapeUpdate)
+    shape : bpy.props.EnumProperty(default="0", items=physicsShapeTypeList, update=handlePhysicsShapeUpdate, options=set())
+    meshObjectName : bpy.props.StringProperty(name="meshName", options=set())
     # TODO: convex hull properties...
-    size0 = bpy.props.FloatProperty(default=1.0, name="size0", update=handlePhysicsShapeUpdate, options=set())
-    size1 = bpy.props.FloatProperty(default=1.0, name="size1", update=handlePhysicsShapeUpdate, options=set())
-    size2 = bpy.props.FloatProperty(default=1.0, name="size2", update=handlePhysicsShapeUpdate, options=set())
+    size0 : bpy.props.FloatProperty(default=1.0, name="size0", update=handlePhysicsShapeUpdate, options=set())
+    size1 : bpy.props.FloatProperty(default=1.0, name="size1", update=handlePhysicsShapeUpdate, options=set())
+    size2 : bpy.props.FloatProperty(default=1.0, name="size2", update=handlePhysicsShapeUpdate, options=set())
 
 class M3RigidBody(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(options=set())
-    boneName = bpy.props.StringProperty(name="boneName", update=handleRigidBodyBoneChange, options=set())
-    unknownAt0 = bpy.props.FloatProperty(default=5.0, name="unknownAt0", options=set())
-    unknownAt4 = bpy.props.FloatProperty(default=4.0, name="unknownAt4", options=set())
-    unknownAt8 = bpy.props.FloatProperty(default=0.8, name="unknownAt8", options=set())
+    name : bpy.props.StringProperty(options=set())
+    boneName : bpy.props.StringProperty(name="boneName", update=handleRigidBodyBoneChange, options=set())
+    unknownAt0 : bpy.props.FloatProperty(default=5.0, name="unknownAt0", options=set())
+    unknownAt4 : bpy.props.FloatProperty(default=4.0, name="unknownAt4", options=set())
+    unknownAt8 : bpy.props.FloatProperty(default=0.8, name="unknownAt8", options=set())
     # skip other unknown values for now
-    physicsShapes = bpy.props.CollectionProperty(type=M3PhysicsShape)
-    physicsShapeIndex = bpy.props.IntProperty(options=set())
-    collidable = bpy.props.BoolProperty(default=True, options=set())
-    walkable = bpy.props.BoolProperty(default=False, options=set())
-    stackable = bpy.props.BoolProperty(default=False, options=set())
-    simulateOnCollision = bpy.props.BoolProperty(default=False, options=set())
-    ignoreLocalBodies = bpy.props.BoolProperty(default=False, options=set())
-    alwaysExists = bpy.props.BoolProperty(default=False, options=set())
-    doNotSimulate = bpy.props.BoolProperty(default=False, options=set())
-    localForces = bpy.props.BoolVectorProperty(default=tuple(16*[False]), size=16, subtype="LAYER", options=set())
-    wind = bpy.props.BoolProperty(default=False, options=set())
-    explosion = bpy.props.BoolProperty(default=False, options=set())
-    energy = bpy.props.BoolProperty(default=False, options=set())
-    blood = bpy.props.BoolProperty(default=False, options=set())
-    magnetic = bpy.props.BoolProperty(default=False, options=set())
-    grass = bpy.props.BoolProperty(default=False, options=set())
-    brush = bpy.props.BoolProperty(default=False, options=set())
-    trees = bpy.props.BoolProperty(default=False, options=set())
-    priority = bpy.props.IntProperty(default=0, options=set())
+    physicsShapes : bpy.props.CollectionProperty(type=M3PhysicsShape)
+    physicsShapeIndex : bpy.props.IntProperty(options=set())
+    collidable : bpy.props.BoolProperty(default=True, options=set())
+    walkable : bpy.props.BoolProperty(default=False, options=set())
+    stackable : bpy.props.BoolProperty(default=False, options=set())
+    simulateOnCollision : bpy.props.BoolProperty(default=False, options=set())
+    ignoreLocalBodies : bpy.props.BoolProperty(default=False, options=set())
+    alwaysExists : bpy.props.BoolProperty(default=False, options=set())
+    doNotSimulate : bpy.props.BoolProperty(default=False, options=set())
+    localForces : bpy.props.BoolVectorProperty(default=tuple(16*[False]), size=16, subtype="LAYER", options=set())
+    wind : bpy.props.BoolProperty(default=False, options=set())
+    explosion : bpy.props.BoolProperty(default=False, options=set())
+    energy : bpy.props.BoolProperty(default=False, options=set())
+    blood : bpy.props.BoolProperty(default=False, options=set())
+    magnetic : bpy.props.BoolProperty(default=False, options=set())
+    grass : bpy.props.BoolProperty(default=False, options=set())
+    brush : bpy.props.BoolProperty(default=False, options=set())
+    trees : bpy.props.BoolProperty(default=False, options=set())
+    priority : bpy.props.IntProperty(default=0, options=set())
 
 class M3AttachmentPoint(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", options=set())
-    updateBlenderBone = bpy.props.BoolProperty(default=True, options=set())
-    boneSuffix = bpy.props.StringProperty(name="boneSuffix", update=handleAttachmentPointTypeOrBoneSuffixChange)
-    boneName = bpy.props.StringProperty(name="boneName", options=set())
-    volumeType = bpy.props.EnumProperty(default="-1",update=handleAttachmentVolumeTypeChange, items=attachmentVolumeTypeList, options=set())
-    volumeSize0 = bpy.props.FloatProperty(default=1.0, options=set(), update=handleAttachmentVolumeSizeChange)
-    volumeSize1 = bpy.props.FloatProperty(default=0.0, options=set(), update=handleAttachmentVolumeSizeChange)
-    volumeSize2 = bpy.props.FloatProperty(default=0.0, options=set(), update=handleAttachmentVolumeSizeChange)
+    name : bpy.props.StringProperty(name="name", options=set())
+    updateBlenderBone : bpy.props.BoolProperty(default=True, options=set())
+    boneSuffix : bpy.props.StringProperty(name="boneSuffix", update=handleAttachmentPointTypeOrBoneSuffixChange)
+    boneName : bpy.props.StringProperty(name="boneName", options=set())
+    volumeType : bpy.props.EnumProperty(default="-1",update=handleAttachmentVolumeTypeChange, items=attachmentVolumeTypeList, options=set())
+    volumeSize0 : bpy.props.FloatProperty(default=1.0, options=set(), update=handleAttachmentVolumeSizeChange)
+    volumeSize1 : bpy.props.FloatProperty(default=0.0, options=set(), update=handleAttachmentVolumeSizeChange)
+    volumeSize2 : bpy.props.FloatProperty(default=0.0, options=set(), update=handleAttachmentVolumeSizeChange)
 
 class M3SimpleGeometricShape(bpy.types.PropertyGroup):
-    name = bpy.props.StringProperty(name="name", default="", options=set())
-    updateBlenderBone = bpy.props.BoolProperty(default=True, options=set())
-    boneName = bpy.props.StringProperty(name="boneName", update=handleGeometicShapeTypeOrBoneNameUpdate, options=set())
-    shape = bpy.props.EnumProperty(default="1", items=geometricShapeTypeList, update=handleGeometicShapeTypeOrBoneNameUpdate, options=set())
-    size0 = bpy.props.FloatProperty(default=1.0, update=handleGeometicShapeUpdate, options=set())
-    size1 = bpy.props.FloatProperty(default=0.0, update=handleGeometicShapeUpdate, options=set())
-    size2 = bpy.props.FloatProperty(default=0.0, update=handleGeometicShapeUpdate, options=set())
-    offset = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", update=handleGeometicShapeUpdate,options=set())
-    rotationEuler = bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="EULER", unit="ROTATION", update=handleGeometicShapeUpdate, options=set())
-    scale = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", update=handleGeometicShapeUpdate, options=set())
+    name : bpy.props.StringProperty(name="name", default="", options=set())
+    updateBlenderBone : bpy.props.BoolProperty(default=True, options=set())
+    boneName : bpy.props.StringProperty(name="boneName", update=handleGeometicShapeTypeOrBoneNameUpdate, options=set())
+    shape : bpy.props.EnumProperty(default="1", items=geometricShapeTypeList, update=handleGeometicShapeTypeOrBoneNameUpdate, options=set())
+    size0 : bpy.props.FloatProperty(default=1.0, update=handleGeometicShapeUpdate, options=set())
+    size1 : bpy.props.FloatProperty(default=0.0, update=handleGeometicShapeUpdate, options=set())
+    size2 : bpy.props.FloatProperty(default=0.0, update=handleGeometicShapeUpdate, options=set())
+    offset : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="XYZ", update=handleGeometicShapeUpdate,options=set())
+    rotationEuler : bpy.props.FloatVectorProperty(default=(0.0, 0.0, 0.0), size=3, subtype="EULER", unit="ROTATION", update=handleGeometicShapeUpdate, options=set())
+    scale : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, subtype="XYZ", update=handleGeometicShapeUpdate, options=set())
 
 class M3BoneVisiblityOptions(bpy.types.PropertyGroup):
-    showFuzzyHitTests = bpy.props.BoolProperty(default=True, options=set(), update=handleFuzzyHitTestVisiblityUpdate)
-    showTightHitTest = bpy.props.BoolProperty(default=True, options=set(), update=handleTightHitTestVisiblityUpdate)
-    showAttachmentPoints = bpy.props.BoolProperty(default=True, options=set(), update=handleAttachmentPointVisibilityUpdate)
-    showParticleSystems = bpy.props.BoolProperty(default=True, options=set(), update=handleParticleSystemsVisiblityUpdate)
-    showRibbons = bpy.props.BoolProperty(default=True, options=set(), update=handleRibbonsVisiblityUpdate)
-    showLights = bpy.props.BoolProperty(default=True, options=set(), update=handleLightsVisiblityUpdate)
-    showForces = bpy.props.BoolProperty(default=True, options=set(), update=handleForcesVisiblityUpdate)
-    showCameras = bpy.props.BoolProperty(default=True, options=set(), update=handleCamerasVisiblityUpdate)
-    showPhysicsShapes = bpy.props.BoolProperty(default=True, options=set(), update=handlePhysicsShapeVisibilityUpdate)
-    showProjections = bpy.props.BoolProperty(default=True, options=set(), update=handleProjectionVisibilityUpdate)
-    showWarps = bpy.props.BoolProperty(default=True, options=set(), update=handleWarpVisibilityUpdate)
+    showFuzzyHitTests : bpy.props.BoolProperty(default=True, options=set(), update=handleFuzzyHitTestVisiblityUpdate)
+    showTightHitTest : bpy.props.BoolProperty(default=True, options=set(), update=handleTightHitTestVisiblityUpdate)
+    showAttachmentPoints : bpy.props.BoolProperty(default=True, options=set(), update=handleAttachmentPointVisibilityUpdate)
+    showParticleSystems : bpy.props.BoolProperty(default=True, options=set(), update=handleParticleSystemsVisiblityUpdate)
+    showRibbons : bpy.props.BoolProperty(default=True, options=set(), update=handleRibbonsVisiblityUpdate)
+    showLights : bpy.props.BoolProperty(default=True, options=set(), update=handleLightsVisiblityUpdate)
+    showForces : bpy.props.BoolProperty(default=True, options=set(), update=handleForcesVisiblityUpdate)
+    showCameras : bpy.props.BoolProperty(default=True, options=set(), update=handleCamerasVisiblityUpdate)
+    showPhysicsShapes : bpy.props.BoolProperty(default=True, options=set(), update=handlePhysicsShapeVisibilityUpdate)
+    showProjections : bpy.props.BoolProperty(default=True, options=set(), update=handleProjectionVisibilityUpdate)
+    showWarps : bpy.props.BoolProperty(default=True, options=set(), update=handleWarpVisibilityUpdate)
 
 class M3ExportOptions(bpy.types.PropertyGroup):
-    path = bpy.props.StringProperty(name="path", default="ExportedModel.m3", options=set())
-    testPatch20Format = bpy.props.BoolProperty(default=False, options=set())
-    animationExportAmount = bpy.props.EnumProperty(default=shared.exportAmountAllAnimations, items=animationExportAmount, options=set())
+    path : bpy.props.StringProperty(name="path", default="ExportedModel.m3", options=set())
+    testPatch20Format : bpy.props.BoolProperty(default=False, options=set())
+    animationExportAmount : bpy.props.EnumProperty(default=shared.exportAmountAllAnimations, items=animationExportAmount, options=set())
 
 class M3ImportOptions(bpy.types.PropertyGroup):
-    path = bpy.props.StringProperty(name="path", default="", options=set())
-    rootDirectory = bpy.props.StringProperty(name="rootDirectory", default="", options=set())
-    generateBlenderMaterials = bpy.props.BoolProperty(default=True, options=set())
-    applySmoothShading = bpy.props.BoolProperty(default=True, options=set())
-    markSharpEdges = bpy.props.BoolProperty(default=True, options=set())
-    recalculateRestPositionBones = bpy.props.BoolProperty(default=False, options=set())
-    teamColor = bpy.props.FloatVectorProperty(default=(1.0, 0.0, 0.0), min = 0.0, max = 1.0, name="team color", size=3, subtype="COLOR", options=set(), description="Team color place holder used for generated blender materials")
-    contentToImport = bpy.props.EnumProperty(default="EVERYTHING", items=contentToImportList, options=set())
+    path : bpy.props.StringProperty(name="path", default="", options=set())
+    rootDirectory : bpy.props.StringProperty(name="rootDirectory", default="", options=set())
+    generateBlenderMaterials : bpy.props.BoolProperty(default=True, options=set())
+    applySmoothShading : bpy.props.BoolProperty(default=True, options=set())
+    markSharpEdges : bpy.props.BoolProperty(default=True, options=set())
+    recalculateRestPositionBones : bpy.props.BoolProperty(default=False, options=set())
+    teamColor : bpy.props.FloatVectorProperty(default=(1.0, 0.0, 0.0), min = 0.0, max = 1.0, name="team color", size=3, subtype="COLOR", options=set(), description="Team color place holder used for generated blender materials")
+    contentToImport : bpy.props.EnumProperty(default="EVERYTHING", items=contentToImportList, options=set())
 
 
 class M3Projection(bpy.types.PropertyGroup):
     # name attribute seems to be needed for template_list but is not actually in the m3 file
     # The name gets calculated like this: name = boneSuffix (type)
-    name = bpy.props.StringProperty(options=set())
-    updateBlenderBone = bpy.props.BoolProperty(default=True, options=set())
-    boneSuffix = bpy.props.StringProperty(options=set(), update=handleProjectionTypeOrBoneSuffixChange, default="Projection")
-    boneName = bpy.props.StringProperty(options=set())
-    materialName = bpy.props.StringProperty(options=set())
-    projectionType = bpy.props.EnumProperty(default=shared.projectionTypeOrthonormal, items=projectionTypeList, options=set(), update=handleProjectionTypeOrBoneSuffixChange)
-    fieldOfView = bpy.props.FloatProperty(default=45.0, name="FOV", options={"ANIMATABLE"}, description="represents the angle (in degrees) that defines the vertical bounds of the projector")
-    aspectRatio = bpy.props.FloatProperty(default=1.0, name="Aspect Ratio", options={"ANIMATABLE"})
-    near = bpy.props.FloatProperty(default=0.5, name="Near", options={"ANIMATABLE"})
-    far = bpy.props.FloatProperty(default=10.0, name="Far", options={"ANIMATABLE"})
-    depth = bpy.props.FloatProperty(default=10.0, name="Depth", options=set(), update=handleProjectionSizeChange)
-    width = bpy.props.FloatProperty(default=10.0, name="Width", options=set(), update=handleProjectionSizeChange)
-    height = bpy.props.FloatProperty(default=10.0, name="Height", options=set(), update=handleProjectionSizeChange)
-    alphaOverTimeStart = bpy.props.FloatProperty(default=0.0, name="Alpha over time start", options=set() )
-    alphaOverTimeMid = bpy.props.FloatProperty(default=1.0, name="Alpha over time mid", options=set() )
-    alphaOverTimeEnd = bpy.props.FloatProperty(default=0.0, name="Alpha over time end", options=set() )
+    name : bpy.props.StringProperty(options=set())
+    updateBlenderBone : bpy.props.BoolProperty(default=True, options=set())
+    boneSuffix : bpy.props.StringProperty(options=set(), update=handleProjectionTypeOrBoneSuffixChange, default="Projection")
+    boneName : bpy.props.StringProperty(options=set())
+    materialName : bpy.props.StringProperty(options=set())
+    projectionType : bpy.props.EnumProperty(default=shared.projectionTypeOrthonormal, items=projectionTypeList, options=set(), update=handleProjectionTypeOrBoneSuffixChange)
+    fieldOfView : bpy.props.FloatProperty(default=45.0, name="FOV", options={"ANIMATABLE"}, description="represents the angle (in degrees) that defines the vertical bounds of the projector")
+    aspectRatio : bpy.props.FloatProperty(default=1.0, name="Aspect Ratio", options={"ANIMATABLE"})
+    near : bpy.props.FloatProperty(default=0.5, name="Near", options={"ANIMATABLE"})
+    far : bpy.props.FloatProperty(default=10.0, name="Far", options={"ANIMATABLE"})
+    depth : bpy.props.FloatProperty(default=10.0, name="Depth", options=set(), update=handleProjectionSizeChange)
+    width : bpy.props.FloatProperty(default=10.0, name="Width", options=set(), update=handleProjectionSizeChange)
+    height : bpy.props.FloatProperty(default=10.0, name="Height", options=set(), update=handleProjectionSizeChange)
+    alphaOverTimeStart : bpy.props.FloatProperty(default=0.0, name="Alpha over time start", options=set() )
+    alphaOverTimeMid : bpy.props.FloatProperty(default=1.0, name="Alpha over time mid", options=set() )
+    alphaOverTimeEnd : bpy.props.FloatProperty(default=0.0, name="Alpha over time end", options=set() )
     
 
 
 class M3Warp(bpy.types.PropertyGroup):
     # name attribute seems to be needed for template_list but is not actually in the m3 file
     # The name gets calculated like this: name = boneSuffix (type)
-    name = bpy.props.StringProperty(options=set())
-    updateBlenderBone = bpy.props.BoolProperty(default=True, options=set())
-    boneSuffix = bpy.props.StringProperty(options=set(), update=handleWarpBoneSuffixChange, default="01")
-    boneName = bpy.props.StringProperty(options=set())
-    materialName = bpy.props.StringProperty(options=set())
+    name : bpy.props.StringProperty(options=set())
+    updateBlenderBone : bpy.props.BoolProperty(default=True, options=set())
+    boneSuffix : bpy.props.StringProperty(options=set(), update=handleWarpBoneSuffixChange, default="01")
+    boneName : bpy.props.StringProperty(options=set())
+    materialName : bpy.props.StringProperty(options=set())
 
-    radius = bpy.props.FloatProperty(default=1.0, min=0.0, name="radius", update=handleWarpRadiusChange, options={"ANIMATABLE"})
-    unknown9306aac0 = bpy.props.FloatProperty(default=10.0, name="unknown9306aac0", options={"ANIMATABLE"})
-    compressionStrength = bpy.props.FloatProperty(default=1.0, name="compressionStrength", options={"ANIMATABLE"})
-    unknown50c7f2b4 = bpy.props.FloatProperty(default=1.0, name="unknown50c7f2b4", options={"ANIMATABLE"})
-    unknown8d9c977c = bpy.props.FloatProperty(default=1.0, name="unknown8d9c977c", options={"ANIMATABLE"})
-    unknownca6025a2 = bpy.props.FloatProperty(default=1.0, name="unknownca6025a2", options={"ANIMATABLE"})
+    radius : bpy.props.FloatProperty(default=1.0, min=0.0, name="radius", update=handleWarpRadiusChange, options={"ANIMATABLE"})
+    unknown9306aac0 : bpy.props.FloatProperty(default=10.0, name="unknown9306aac0", options={"ANIMATABLE"})
+    compressionStrength : bpy.props.FloatProperty(default=1.0, name="compressionStrength", options={"ANIMATABLE"})
+    unknown50c7f2b4 : bpy.props.FloatProperty(default=1.0, name="unknown50c7f2b4", options={"ANIMATABLE"})
+    unknown8d9c977c : bpy.props.FloatProperty(default=1.0, name="unknown8d9c977c", options={"ANIMATABLE"})
+    unknownca6025a2 : bpy.props.FloatProperty(default=1.0, name="unknownca6025a2", options={"ANIMATABLE"})
 
 
 class M3Light(bpy.types.PropertyGroup):
     # name attribute seems to be needed for template_list but is not actually in the m3 file
     # The name gets calculated like this: name = boneSuffix (type)
-    name = bpy.props.StringProperty(name="name", default="", options=set())
-    updateBlenderBone = bpy.props.BoolProperty(default=True, options=set())
-    lightType = bpy.props.EnumProperty(default="1", items=lightTypeList, options=set(), update=handleLightTypeOrBoneSuffixChange)
-    boneSuffix = bpy.props.StringProperty(options=set(), update=handleLightTypeOrBoneSuffixChange, default="Particle System")
-    boneName = bpy.props.StringProperty(options=set())
-    lightColor = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=3, subtype="COLOR", options={"ANIMATABLE"})
-    lightIntensity = bpy.props.FloatProperty(default=1.0, name="Light Intensity", options={"ANIMATABLE"})
-    specColor =  bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=3, subtype="COLOR", options={"ANIMATABLE"})
-    specIntensity = bpy.props.FloatProperty(default=0.0, name="Specular Intensity", options={"ANIMATABLE"})
-    attenuationNear = bpy.props.FloatProperty(default=2.5, name="attenuationNear", options={"ANIMATABLE"})
-    unknownAt148 = bpy.props.FloatProperty(default=2.5, name="unknownAt148", options=set())
-    attenuationFar = bpy.props.FloatProperty(default=3.0, name="attenuationFar", update=handleLightSizeChange, options={"ANIMATABLE"})
-    hotSpot = bpy.props.FloatProperty(default=1.0, name="Hot Spot", options={"ANIMATABLE"})
-    falloff = bpy.props.FloatProperty(default=1.0, name="Fall Off", update=handleLightSizeChange, options={"ANIMATABLE"})
-    unknownAt12 = bpy.props.IntProperty(default=-1, name="unknownAt12", options=set())
-    unknownAt8 = bpy.props.BoolProperty(default=False,options=set())
-    shadowCast = bpy.props.BoolProperty(options=set())
-    specular = bpy.props.BoolProperty(options=set())
-    unknownFlag0x04 = bpy.props.BoolProperty(options=set())
-    turnOn = bpy.props.BoolProperty(default=True,options=set())
+    name : bpy.props.StringProperty(name="name", default="", options=set())
+    updateBlenderBone : bpy.props.BoolProperty(default=True, options=set())
+    lightType : bpy.props.EnumProperty(default="1", items=lightTypeList, options=set(), update=handleLightTypeOrBoneSuffixChange)
+    boneSuffix : bpy.props.StringProperty(options=set(), update=handleLightTypeOrBoneSuffixChange, default="Particle System")
+    boneName : bpy.props.StringProperty(options=set())
+    lightColor : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=3, subtype="COLOR", options={"ANIMATABLE"})
+    lightIntensity : bpy.props.FloatProperty(default=1.0, name="Light Intensity", options={"ANIMATABLE"})
+    specColor : bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), min = 0.0, max = 1.0, size=3, subtype="COLOR", options={"ANIMATABLE"})
+    specIntensity : bpy.props.FloatProperty(default=0.0, name="Specular Intensity", options={"ANIMATABLE"})
+    attenuationNear : bpy.props.FloatProperty(default=2.5, name="attenuationNear", options={"ANIMATABLE"})
+    unknownAt148 : bpy.props.FloatProperty(default=2.5, name="unknownAt148", options=set())
+    attenuationFar : bpy.props.FloatProperty(default=3.0, name="attenuationFar", update=handleLightSizeChange, options={"ANIMATABLE"})
+    hotSpot : bpy.props.FloatProperty(default=1.0, name="Hot Spot", options={"ANIMATABLE"})
+    falloff : bpy.props.FloatProperty(default=1.0, name="Fall Off", update=handleLightSizeChange, options={"ANIMATABLE"})
+    unknownAt12 : bpy.props.IntProperty(default=-1, name="unknownAt12", options=set())
+    unknownAt8 : bpy.props.BoolProperty(default=False,options=set())
+    shadowCast : bpy.props.BoolProperty(options=set())
+    specular : bpy.props.BoolProperty(options=set())
+    unknownFlag0x04 : bpy.props.BoolProperty(options=set())
+    turnOn : bpy.props.BoolProperty(default=True,options=set())
     
 class M3BillboardBehavior(bpy.types.PropertyGroup):
     # name is also bone name
-    name = bpy.props.StringProperty(name="name", default="", options=set())
-    billboardType = bpy.props.EnumProperty(default="6", items=billboardBehaviorTypeList, options=set())
+    name : bpy.props.StringProperty(name="name", default="", options=set())
+    billboardType : bpy.props.EnumProperty(default="6", items=billboardBehaviorTypeList, options=set())
                                           
 class ImportPanel(bpy.types.Panel):
     bl_idname = "OBJECT_PT_M3_quickImport"
@@ -1901,8 +1901,8 @@ class AnimationSequencesPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_animations", scene, "m3_animations", scene, "m3_animation_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.animations_add", icon='ZOOMIN', text="")
-        col.operator("m3.animations_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.animations_add", icon='ZOOM_IN', text="")
+        col.operator("m3.animations_remove", icon='ZOOM_OUT', text="")
         col.menu("OBJECT_MT_M3_animations_menu", icon='DOWNARROW_HLT', text="")
         animationIndex = scene.m3_animation_index
         if animationIndex >= 0 and animationIndex < len(scene.m3_animations):
@@ -1944,8 +1944,8 @@ class AnimationSequenceTransformationCollectionsPanel(bpy.types.Panel):
             col.template_list("UI_UL_list", "m3_stcs", animation, "transformationCollections", animation, "transformationCollectionIndex", rows=2)
             
             col = row.column(align=True)
-            col.operator("m3.stc_add", icon='ZOOMIN', text="")
-            col.operator("m3.stc_remove", icon='ZOOMOUT', text="")
+            col.operator("m3.stc_add", icon='ZOOM_IN', text="")
+            col.operator("m3.stc_remove", icon='ZOOM_OUT', text="")
             index = animation.transformationCollectionIndex
             if index >= 0 and index < len(animation.transformationCollections):
                 transformationCollection = animation.transformationCollections[index]
@@ -1975,8 +1975,8 @@ class MaterialReferencesPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_material_references", scene, "m3_material_references", scene, "m3_material_reference_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.materials_add", icon='ZOOMIN', text="")
-        col.operator("m3.materials_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.materials_add", icon='ZOOM_IN', text="")
+        col.operator("m3.materials_remove", icon='ZOOM_OUT', text="")
 
 
 
@@ -2001,7 +2001,7 @@ class MaterialSelectionPanel(bpy.types.Panel):
         row = layout.row()
 
         row.prop_search(mesh, 'm3_material_name', scene, 'm3_material_references', text="M3 Material", icon='NONE')
-        row.operator("m3.create_material_for_mesh", icon='ZOOMIN', text="")
+        row.operator("m3.create_material_for_mesh", icon='ZOOM_IN', text="")
 
 def displayMaterialPropertiesUI(scene, layout, materialReference):
         materialType = materialReference.materialType
@@ -2055,7 +2055,7 @@ def displayMaterialPropertiesUI(scene, layout, materialReference):
 
 
             split = layout.split(align=True)
-            split.label("Required On Low End:")
+            split.label(text = "Required On Low End:")
 
             box = layout.box()
             col = box.column_flow()
@@ -2071,14 +2071,14 @@ def displayMaterialPropertiesUI(scene, layout, materialReference):
         elif materialType == shared.compositeMaterialTypeIndex:
             material = scene.m3_composite_materials[materialIndex]
             layout.prop(material, 'name', text="Name")
-            layout.label("Sections:")
+            layout.label(text = "Sections:")
             row = layout.row()
             col = row.column()
             col.template_list("UI_UL_list", "m3_material_sections", material, "sections", material, "sectionIndex", rows=2)
             
             col = row.column(align=True)
-            col.operator("m3.composite_material_add_section", icon='ZOOMIN', text="")
-            col.operator("m3.composite_material_remove_section", icon='ZOOMOUT', text="")
+            col.operator("m3.composite_material_add_section", icon='ZOOM_IN', text="")
+            col.operator("m3.composite_material_remove_section", icon='ZOOM_OUT', text="")
             sectionIndex = material.sectionIndex
             if (sectionIndex >= 0) and (sectionIndex < len(material.sections)):
                 section = material.sections[sectionIndex]
@@ -2249,12 +2249,12 @@ def displayMaterialLayersUI(scene, layout, materialReference):
             sub.prop(layer, 'fresnelMin', text="Min")
             sub.prop(layer, 'fresnelMax', text="Max")
             sub = box.column(align=True)
-            sub.label("Mask")
+            sub.label(text = "Mask")
             sub.prop(layer, 'fresnelMaskX', text="X", slider=True)
             sub.prop(layer, 'fresnelMaskY', text="Y", slider=True)
             sub.prop(layer, 'fresnelMaskZ', text="Z", slider=True)
             sub = box.column(align=True)
-            sub.label("Rotation")
+            sub.label(text = "Rotation")
             sub.prop(layer, 'fresnelRotationYaw', text="Yaw")
             sub.prop(layer, 'fresnelRotationPitch', text="Pitch")
             sub = box.column(align=True)
@@ -2335,8 +2335,8 @@ class CameraPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_cameras", scene, "m3_cameras", scene, "m3_camera_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.cameras_add", icon='ZOOMIN', text="")
-        col.operator("m3.cameras_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.cameras_add", icon='ZOOM_IN', text="")
+        col.operator("m3.cameras_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_camera_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_cameras):
             camera = scene.m3_cameras[currentIndex]
@@ -2368,8 +2368,8 @@ class ParticleSystemsPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_particle_systems", scene, "m3_particle_systems", scene, "m3_particle_system_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.particle_systems_add", icon='ZOOMIN', text="")
-        col.operator("m3.particle_systems_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.particle_systems_add", icon='ZOOM_IN', text="")
+        col.operator("m3.particle_systems_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_particle_system_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_particle_systems):
             particle_system = scene.m3_particle_systems[currentIndex]
@@ -2378,7 +2378,7 @@ class ParticleSystemsPanel(bpy.types.Panel):
             layout.prop_search(particle_system, 'materialName', scene, 'm3_material_references', text="Material", icon='NONE')
             split = layout.split()
             col = split.column()
-            col.row().label("Emis. Area:")
+            col.row().label(text = "Emis. Area:")
             subcol = col.row().column(align=True)
             subcol.prop(particle_system, 'emissionAreaType', text="")
             sub = subcol.row()
@@ -2574,7 +2574,7 @@ class ParticleSystemsPanel(bpy.types.Panel):
 
             split = layout.split()
             col = split.column()
-            col.label("Noise:")
+            col.label(text = "Noise:")
             sub = col.column(align=True)
             sub.prop(particle_system, "noiseAmplitude", text="Amplitude")
             sub.prop(particle_system, "noiseFrequency", text="Frequency")
@@ -2651,8 +2651,8 @@ class RibbonsPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_ribbons", scene, "m3_ribbons", scene, "m3_ribbon_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.ribbons_add", icon='ZOOMIN', text="")
-        col.operator("m3.ribbons_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.ribbons_add", icon='ZOOM_IN', text="")
+        col.operator("m3.ribbons_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_ribbon_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_ribbons):
             ribbon = scene.m3_ribbons[currentIndex]
@@ -2762,8 +2762,8 @@ class RibbonEndPointsPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_ribbon_end_points", ribbon, "endPoints", ribbon, "endPointIndex", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.ribbon_end_points_add", icon='ZOOMIN', text="")
-        col.operator("m3.ribbon_end_points_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.ribbon_end_points_add", icon='ZOOM_IN', text="")
+        col.operator("m3.ribbon_end_points_remove", icon='ZOOM_OUT', text="")
         
         endPointIndex = ribbon.endPointIndex
         if endPointIndex < 0 or endPointIndex >= len(ribbon.endPoints):
@@ -2789,8 +2789,8 @@ class ForcePanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_forces", scene, "m3_forces", scene, "m3_force_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.forces_add", icon='ZOOMIN', text="")
-        col.operator("m3.forces_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.forces_add", icon='ZOOM_IN', text="")
+        col.operator("m3.forces_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_force_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_forces):
             force = scene.m3_forces[currentIndex]
@@ -2823,8 +2823,8 @@ class RigidBodyPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_rigid_bodies", scene, "m3_rigid_bodies", scene, "m3_rigid_body_index", rows=2)
         
         col = row.column(align=True)
-        col.operator("m3.rigid_bodies_add", icon='ZOOMIN', text="")
-        col.operator("m3.rigid_bodies_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.rigid_bodies_add", icon='ZOOM_IN', text="")
+        col.operator("m3.rigid_bodies_remove", icon='ZOOM_OUT', text="")
         
         currentIndex = scene.m3_rigid_body_index
         if not 0 <= currentIndex < len(scene.m3_rigid_bodies):
@@ -2891,14 +2891,14 @@ class PhyscisShapePanel(bpy.types.Panel):
         
         currentIndex = scene.m3_rigid_body_index
         if not 0 <= currentIndex < len(scene.m3_rigid_bodies):
-            layout.label("No rigid body has been selected")
+            layout.label(text = "No rigid body has been selected")
             return
         rigid_body = scene.m3_rigid_bodies[currentIndex]
         
         col.template_list("UI_UL_list", "m3_physics_sahpes", rigid_body, "physicsShapes", rigid_body, "physicsShapeIndex", rows=2)
         col = row.column(align=True)
-        col.operator("m3.physics_shapes_add", icon='ZOOMIN', text="")
-        col.operator("m3.physics_shapes_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.physics_shapes_add", icon='ZOOM_IN', text="")
+        col.operator("m3.physics_shapes_remove", icon='ZOOM_OUT', text="")
         
         currentIndex = rigid_body.physicsShapeIndex
         if not 0 <= currentIndex < len(rigid_body.physicsShapes):
@@ -2963,8 +2963,8 @@ class LightPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_lights", scene, "m3_lights", scene, "m3_light_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.lights_add", icon='ZOOMIN', text="")
-        col.operator("m3.lights_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.lights_add", icon='ZOOM_IN', text="")
+        col.operator("m3.lights_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_light_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_lights):
             light = scene.m3_lights[currentIndex]
@@ -3013,8 +3013,8 @@ class BillboardBehaviorPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_billboard_behaviors", scene, "m3_billboard_behaviors", scene, "m3_billboard_behavior_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.billboard_behaviors_add", icon='ZOOMIN', text="")
-        col.operator("m3.billboard_behaviors_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.billboard_behaviors_add", icon='ZOOM_IN', text="")
+        col.operator("m3.billboard_behaviors_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_billboard_behavior_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_billboard_behaviors):
             billboardBehavior = scene.m3_billboard_behaviors[currentIndex]
@@ -3038,8 +3038,8 @@ class ProjectionPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_projections", scene, "m3_projections", scene, "m3_projection_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.projections_add", icon='ZOOMIN', text="")
-        col.operator("m3.projections_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.projections_add", icon='ZOOM_IN', text="")
+        col.operator("m3.projections_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_projection_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_projections):
             projection = scene.m3_projections[currentIndex]
@@ -3049,14 +3049,14 @@ class ProjectionPanel(bpy.types.Panel):
             layout.prop_search(projection, 'materialName', scene, 'm3_material_references', text="Material", icon='NONE')
             split = layout.split()
             col = split.column()
-            col.label("Orthonormal")
+            col.label(text = "Orthonormal")
             col.prop(projection, 'depth', text="Depth")
             col.prop(projection, 'width', text="Width")
             col.prop(projection, 'height', text="Height")
             col.active = (projection.projectionType == shared.projectionTypeOrthonormal)
             split = layout.split()
             col = split.column()
-            col.label("Perspective")
+            col.label(text = "Perspective")
             col.prop(projection, 'fieldOfView', text="FOV")
             col.prop(projection, 'aspectRatio', text="Aspect Ratio")
             col.prop(projection, 'near', text="Near")
@@ -3098,8 +3098,8 @@ class WarpPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_warps", scene, "m3_warps", scene, "m3_warp_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.warps_add", icon='ZOOMIN', text="")
-        col.operator("m3.warps_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.warps_add", icon='ZOOM_IN', text="")
+        col.operator("m3.warps_remove", icon='ZOOM_OUT', text="")
         currentIndex = scene.m3_warp_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_warps):
             warp = scene.m3_warps[currentIndex]
@@ -3128,15 +3128,15 @@ class ParticleSystemCopiesPanel(bpy.types.Panel):
         
         particleSystemIndex = scene.m3_particle_system_index
         if not(particleSystemIndex >= 0 and particleSystemIndex < len(scene.m3_particle_systems)):
-            layout.label("No particle system has been selected")
+            layout.label(text = "No particle system has been selected")
             return
         particle_system = scene.m3_particle_systems[particleSystemIndex]
         copyIndex = particle_system.copyIndex            
         col.template_list("UI_UL_list", "m3_particle_system_copies", particle_system, "copies", particle_system, "copyIndex", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.particle_system_copies_add", icon='ZOOMIN', text="")
-        col.operator("m3.particle_system_copies_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.particle_system_copies_add", icon='ZOOM_IN', text="")
+        col.operator("m3.particle_system_copies_remove", icon='ZOOM_OUT', text="")
         if copyIndex >= 0 and copyIndex < len(particle_system.copies):
             copy = particle_system.copies[copyIndex]
             layout.separator()
@@ -3161,8 +3161,8 @@ class AttachmentPointsPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_attachment_points", scene, "m3_attachment_points", scene, "m3_attachment_point_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.attachment_points_add", icon='ZOOMIN', text="")
-        col.operator("m3.attachment_points_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.attachment_points_add", icon='ZOOM_IN', text="")
+        col.operator("m3.attachment_points_remove", icon='ZOOM_OUT', text="")
 
         currentIndex = scene.m3_attachment_point_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_attachment_points):
@@ -3240,8 +3240,8 @@ class FuzzyHitTestPanel(bpy.types.Panel):
         col.template_list("UI_UL_list", "m3_fuzzy_hit_tests", scene, "m3_fuzzy_hit_tests", scene, "m3_fuzzy_hit_test_index", rows=2)
 
         col = row.column(align=True)
-        col.operator("m3.fuzzy_hit_tests_add", icon='ZOOMIN', text="")
-        col.operator("m3.fuzzy_hit_tests_remove", icon='ZOOMOUT', text="")
+        col.operator("m3.fuzzy_hit_tests_add", icon='ZOOM_IN', text="")
+        col.operator("m3.fuzzy_hit_tests_remove", icon='ZOOM_OUT', text="")
 
         currentIndex = scene.m3_fuzzy_hit_test_index
         if currentIndex >= 0 and currentIndex < len(scene.m3_fuzzy_hit_tests):
@@ -3298,8 +3298,8 @@ class M3_MATERIALS_OT_add(bpy.types.Operator):
     bl_label       = "Add M3 Material"
     bl_description = "Adds an material for the export to Starcraft 2"
 
-    defaultSetting = bpy.props.EnumProperty(items=matDefaultSettingsList, options=set(), default="MESH")
-    materialName = bpy.props.StringProperty(name="materialName", default="01", options=set())
+    defaultSetting : bpy.props.EnumProperty(items=matDefaultSettingsList, options=set(), default="MESH")
+    materialName : bpy.props.StringProperty(name="materialName", default="01", options=set())
     
     def invoke(self, context, event):
         scene = context.scene
@@ -3323,8 +3323,8 @@ class M3_MATERIALS_OT_createForMesh(bpy.types.Operator):
     bl_label       = "Creates a M3 Material for the current mesh"
     bl_description = "Creates an m3 material for the current mesh"
 
-    defaultSetting = bpy.props.EnumProperty(items=matDefaultSettingsList, options=set(), default="MESH")
-    materialName = bpy.props.StringProperty(name="materialName", default="01", options=set())
+    defaultSetting : bpy.props.EnumProperty(items=matDefaultSettingsList, options=set(), default="MESH")
+    materialName : bpy.props.StringProperty(name="materialName", default="01", options=set())
     
     def invoke(self, context, event):
         scene = context.scene
@@ -3524,9 +3524,9 @@ def copyCurrentActionOfObjectToM3Animation(objectWithAnimationData, targetAnimat
         arrayIndex = sourceCurve.array_index
         if sourceCurve.group != None:
             groupName = sourceCurve.group.name
-            targetCurve = newAction.fcurves.new(path, arrayIndex, groupName)
+            targetCurve = newAction.fcurves.new(path, index = arrayIndex, action_group = groupName)
         else:
-            targetCurve = newAction.fcurves.new(path, arrayIndex)
+            targetCurve = newAction.fcurves.new(path, index = arrayIndex)
         targetCurve.extrapolation = sourceCurve.extrapolation
         targetCurve.color_mode = sourceCurve.color_mode
         targetCurve.color = sourceCurve.color
@@ -3671,10 +3671,10 @@ class M3_ANIMATIONS_OT_STC_select(bpy.types.Operator):
                     locLongAnimId = shared.getLongAnimIdOf(objectId, animPathPrefix + "location")
                     scaleLongAnimId = shared.getLongAnimIdOf(objectId, animPathPrefix + "scale")
                     if (rotLongAnimId in longAnimIds) or (locLongAnimId in longAnimIds) or (scaleLongAnimId in longAnimIds):
-                        bone.select = True
+                        bone.select_set(True)
                         selectObject = True
                     else:
-                        bone.select = False
+                        bone.select_set(False)
                 # Select object at the end, otherwise Blender 2.63a
                 # does not notice bone selection even if object is already selected
                 obj.select = selectObject
@@ -3814,7 +3814,7 @@ class M3_PARTICLE_SYSTEMS_OT_create_spawn_points_from_mesh(bpy.types.Operator):
             activeObject = context.active_object 
             if activeObject != None and activeObject.type == 'MESH':
                 mesh = activeObject.data
-                mesh.update(calc_tessface=True)
+                mesh.update(calc_loop_triangles=True)
                 particleSystem.spawnPoints.clear()
                 for vertex in mesh.vertices:
                     spawnPoint = particleSystem.spawnPoints.add()
@@ -4559,9 +4559,9 @@ class M3_OT_export(bpy.types.Operator, ExportHelper):
     bl_options = {'UNDO'}
 
     filename_ext = ".m3"
-    filter_glob = StringProperty(default="*.m3", options={'HIDDEN'})
+    filter_glob : StringProperty(default="*.m3", options={'HIDDEN'})
 
-    filepath = bpy.props.StringProperty(
+    filepath : bpy.props.StringProperty(
         name="File Path", 
         description="Path of the file that should be created", 
         maxlen= 1024, default= "")
@@ -4588,9 +4588,9 @@ class M3_OT_import(bpy.types.Operator, ImportHelper):
     bl_options = {'UNDO'}
 
     filename_ext = ".m3"
-    filter_glob = StringProperty(default="*.m3;*.m3a", options={'HIDDEN'})
+    filter_glob : StringProperty(default="*.m3;*.m3a", options={'HIDDEN'})
 
-    filepath = bpy.props.StringProperty(
+    filepath : bpy.props.StringProperty(
         name="File Path", 
         description="File path used for importing the simple M3 file", 
         maxlen= 1024, default= "")
@@ -4702,14 +4702,134 @@ def menu_func_convertNormalMaps(self, context):
 
 
 def menu_func_import(self, context):
-    self.layout.operator(M3_OT_import.bl_idname, text="Starcraft 2 Model (.m3)...")
+    self.layout.operator(M3_OT_import.bl_idname, text="StarCraft 2 Model / Animation (.m3/.m3a)...")
     
 def menu_func_export(self, context):
-    self.layout.operator(M3_OT_export.bl_idname, text="Starcraft 2 Model (.m3)...")
+    self.layout.operator(M3_OT_export.bl_idname, text="StarCraft 2 Model (.m3)...")
  
-def register():
-    bpy.utils.register_module(__name__)
 
+classes = (
+    M3AnimatedPropertyReference,
+    AssignedActionOfM3Animation,
+    M3TransformationCollection,
+    M3MaterialLayer,
+    M3CompositeMaterialSection,
+    M3ParticleSpawnPoint,
+    M3ParticleSystemCopy,
+    M3RibbonEndPoint,
+    M3PhysicsShape,
+    M3Animation,
+    M3Material,
+    M3StandardMaterial,
+    M3DisplacementMaterial,
+    M3CompositeMaterial,
+    M3TerrainMaterial,
+    M3VolumeMaterial,
+    M3VolumeNoiseMaterial,
+    M3CreepMaterial,
+    M3STBMaterial,
+    M3LensFlareMaterial,
+    M3Camera,
+    M3ParticleSystem,
+    M3Ribbon,
+    M3Force,
+    M3RigidBody,
+    M3Light,
+    M3BillboardBehavior,
+    M3Projection,
+    M3Warp,
+    M3AttachmentPoint,
+    M3ExportOptions,
+    M3ImportOptions,
+    M3BoneVisiblityOptions,
+    M3Boundings,
+    M3AnimIdData,
+    M3SimpleGeometricShape,
+    ImportPanel,
+    ExportPanel,
+    BoneVisibilityPanel,
+    BasicMenu,
+    AnimationSequencesPanel,
+    AnimationSequenceTransformationCollectionsPanel,
+    MaterialReferencesPanel,
+    MaterialSelectionPanel,
+    MaterialPropertiesPanel,
+    ObjectMaterialPropertiesPanel,
+    MatrialLayersPanel,
+    ObjectMatrialLayersPanel,
+    CameraPanel,
+    ParticleSystemsPanel,
+    RibbonsPanel,
+    RibbonEndPointsPanel,
+    ForcePanel,
+    RigidBodyPanel,
+    PhyscisShapePanel,
+    PhysicsMeshPanel,
+    VisbilityTestPanel,
+    LightPanel,
+    BillboardBehaviorPanel,
+    ProjectionPanel,
+    WarpPanel,
+    ParticleSystemCopiesPanel,
+    AttachmentPointsPanel,
+    FuzzyHitTestPanel,
+    TightHitTestPanel,
+    ExtraBonePropertiesPanel,
+    M3_MATERIALS_OT_add,
+    M3_MATERIALS_OT_createForMesh,
+    M3_MATERIALS_OT_remove,
+    M3_COMPOSITE_MATERIAL_OT_add_section,
+    M3_COMPOSITE_MATERIAL_OT_remove_section,
+    M3_ANIMATIONS_OT_add,
+    M3_ANIMATIONS_OT_remove,
+    M3_ANIMATIONS_OT_duplicate,
+    M3_ANIMATIONS_OT_deselect,
+    M3_ANIMATIONS_OT_STC_add,
+    M3_ANIMATIONS_OT_STC_remove,
+    M3_ANIMATIONS_OT_STC_select,
+    M3_ANIMATIONS_OT_STC_assign,
+    M3_CAMERAS_OT_add,
+    M3_CAMERAS_OT_remove,
+    M3_PARTICLE_SYSTEMS_OT_create_spawn_points_from_mesh,
+    M3_PARTICLE_SYSTEMS_OT_add,
+    M3_PARTICLE_SYSTEMS_OT_remove,
+    M3_PARTICLE_SYSTEM_COPIES_OT_add,
+    M3_PARTICLE_SYSTEMS_COPIES_OT_remove,
+    M3_RIBBONS_OT_add,
+    M3_RIBBONS_OT_remove,
+    M3_RIBBON_END_POINTS_OT_add,
+    M3_RIBBON_END_POINTS_OT_remove,
+    M3_FORCES_OT_add,
+    M3_FORCES_OT_remove,
+    M3_RIGID_BODIES_OT_add,
+    M3_RIGID_BODIES_OT_remove,
+    M3_PHYSICS_SHAPES_OT_add,
+    M3_PHYSICS_SHAPES_OT_remove,
+    M3_LIGHTS_OT_add,
+    M3_LIGHTS_OT_remove,
+    M3_BILLBOARD_BEHAVIORS_OT_add,
+    M3_BILLBOARD_BEHAVIORS_OT_remove,
+    M3_PROJECTIONS_OT_add,
+    M3_PROJECTIONS_OT_remove,
+    M3_WARPS_OT_add,
+    M3_WARPS_OT_remove,
+    M3_ATTACHMENT_POINTS_OT_add,
+    M3_TIGHT_HIT_TESTS_OT_selectorcreatebone,
+    M3_TIGHT_HIT_TESTS_OT_hittestremove,
+    M3_FUZZY_HIT_TESTS_OT_add,
+    M3_FUZZY_HIT_TESTS_OT_remove,
+    M3_ATTACHMENT_POINTS_OT_remove,
+    M3_OT_quickExport,
+    M3_OT_quickImport,
+    M3_OT_generateBlenderMaterails,
+    M3_OT_export,
+    M3_OT_import,
+    M3_OT_conertBlenderToM3NormalMap,
+    M3_OT_conertM3ToBlenderNormalMap,
+)
+
+def register():
+    for cls in classes: bpy.utils.register_class(cls)
     bpy.types.Scene.m3_animation_index = bpy.props.IntProperty(update=handleAnimationSequenceIndexChange, options=set())
     bpy.types.Scene.m3_animation_old_index = bpy.props.IntProperty(options=set())
     bpy.types.Scene.m3_animations = bpy.props.CollectionProperty(type=M3Animation)
@@ -4755,19 +4875,18 @@ def register():
     bpy.types.Scene.m3_tight_hit_test = bpy.props.PointerProperty(type=M3SimpleGeometricShape)
     bpy.types.Mesh.m3_material_name = bpy.props.StringProperty(options=set())
     bpy.types.Mesh.m3_physics_mesh = bpy.props.BoolProperty(default=False, options=set(), description="Mark mesh to be used for physics shape only (not exported).")
-    bpy.types.INFO_MT_file_import.append(menu_func_import)
-    bpy.types.INFO_MT_file_export.append(menu_func_export)
+    bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
     bpy.types.IMAGE_MT_image.append(menu_func_convertNormalMaps)
     bpy.types.Bone.m3_bind_scale = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, options=set()) 
     bpy.types.EditBone.m3_bind_scale = bpy.props.FloatVectorProperty(default=(1.0, 1.0, 1.0), size=3, options=set()) 
     bpy.types.Scene.m3_default_value_action_assignments = bpy.props.CollectionProperty(type=AssignedActionOfM3Animation, options=set())
 
-
  
 def unregister():
-    bpy.utils.unregister_module(__name__)
-    bpy.types.INFO_MT_file_import.remove(menu_func_import)
-    bpy.types.INFO_MT_file_export.remove(menu_func_export)
+    for cls in reverse(classes): bpy.utils.unregister_class(cls)
+    bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
     bpy.types.IMAGE_MT_image.remove(menu_func_convertNormalMaps)
  
 if __name__ == "__main__":

--- a/m3import.py
+++ b/m3import.py
@@ -155,7 +155,7 @@ def visualizeMatrix(matrix, at3DCursor):
     zVertex = oVertex + matrix3x3.col[2]
     vertices = [oVertex, xVertex,yVertex,zVertex]
     edges = [(0,1),(0,2),(0,3)]
-    bpy.context.scene.objects.link(meshObject)
+    bpy.context.scene.collection.objects.link(meshObject)
     mesh.from_pydata(vertices, edges, [])
     mesh.update(calc_edges=True)
     
@@ -238,7 +238,7 @@ def determineAbsoluteBoneRestPositions(model):
     for inverseBoneRestPosition in model.absoluteInverseBoneRestPositions:
         matrix = toBlenderMatrix(inverseBoneRestPosition.matrix)
         matrix = matrix.inverted()
-        matrix = matrix * shared.rotFixMatrix        
+        matrix = matrix @ shared.rotFixMatrix        
         matrices.append(matrix)
     return matrices
 
@@ -471,9 +471,9 @@ class Importer:
         scene = bpy.context.scene
         armatureObject = bpy.data.objects.new("Armature Object", self.armature)
         armatureObject.location = scene.cursor_location
-        scene.objects.link(armatureObject)
-        scene.objects.active = armatureObject
-        armatureObject.select = True
+        scene.collection.objects.link(armatureObject)
+        scene.view_layers[0].objects.active = armatureObject
+        armatureObject.select_set(True)
         self.armatureObject = armatureObject
 
         
@@ -558,13 +558,13 @@ class Importer:
             if bone.parent != -1:
                 # TODO perforamcne optimization: cache bindScaleMatrices[bone.parent].inverted()
                 # TODO find out why it's just the scale that need to be applied
-                leftCorrectionMatrix = relEditBoneMatrix.inverted() * shared.rotFixMatrixInverted * bindScaleMatrices[bone.parent].inverted()
+                leftCorrectionMatrix = relEditBoneMatrix.inverted() @ shared.rotFixMatrixInverted @ bindScaleMatrices[bone.parent].inverted()
             else:
                 leftCorrectionMatrix = relEditBoneMatrix.inverted()
-            rightCorrectionMatrix = bindMatrix * shared.rotFixMatrix
+            rightCorrectionMatrix = bindMatrix @ shared.rotFixMatrix
 
             poseBoneTransform = shared.locRotScaleMatrix(location, rotation, scale)
-            poseBoneTransform = leftCorrectionMatrix * poseBoneTransform * rightCorrectionMatrix
+            poseBoneTransform = leftCorrectionMatrix @ poseBoneTransform @ rightCorrectionMatrix
             location, rotation, scale = poseBoneTransform.decompose()
 
             poseBone.scale = scale
@@ -607,7 +607,7 @@ class Importer:
             scale = toBlenderVector3(scale)
             relSpecifiedMatrix = shared.locRotScaleMatrix(location, rotation, scale)
 
-            newMatrix = leftCorrectionMatrix * relSpecifiedMatrix * rightCorrectionMatrix
+            newMatrix = leftCorrectionMatrix @ relSpecifiedMatrix @ rightCorrectionMatrix
             location, rotation, scale = newMatrix.decompose()
             timeToLocationMap[timeInMS] = location
             timeToRotationMap[timeInMS] = rotation
@@ -668,9 +668,9 @@ class Importer:
 
             group = boneName
             if locationAnimId in animIdToTimeValueMap:
-                locXCurve = action.fcurves.new(locationAnimPath, 0, group)
-                locYCurve = action.fcurves.new(locationAnimPath, 1, group)
-                locZCurve = action.fcurves.new(locationAnimPath, 2, group)
+                locXCurve = action.fcurves.new(locationAnimPath, index = 0, action_group = group)
+                locYCurve = action.fcurves.new(locationAnimPath, index = 1, action_group = group)
+                locZCurve = action.fcurves.new(locationAnimPath, index = 2, action_group = group)
                 for timeInMS, frame in zip(timeEntries, frames):
                     location = timeToLocationMap.get(timeInMS)
                     insertLinearKeyFrame(locXCurve, frame, location.x)
@@ -678,10 +678,10 @@ class Importer:
                     insertLinearKeyFrame(locZCurve, frame, location.z)
             
             if rotationAnimId in animIdToTimeValueMap:
-                rotWCurve = action.fcurves.new(rotationAnimPath, 0, group)
-                rotXCurve = action.fcurves.new(rotationAnimPath, 1, group)
-                rotYCurve = action.fcurves.new(rotationAnimPath, 2, group)
-                rotZCurve = action.fcurves.new(rotationAnimPath, 3, group)
+                rotWCurve = action.fcurves.new(rotationAnimPath, index = 0, action_group = group)
+                rotXCurve = action.fcurves.new(rotationAnimPath, index = 1, action_group = group)
+                rotYCurve = action.fcurves.new(rotationAnimPath, index = 2, action_group = group)
+                rotZCurve = action.fcurves.new(rotationAnimPath, index = 3, action_group = group)
                 for timeInMS, frame in zip(timeEntries, frames):
                     rotation = timeToRotationMap.get(timeInMS)
                     insertLinearKeyFrame(rotWCurve, frame, rotation.w)
@@ -690,9 +690,9 @@ class Importer:
                     insertLinearKeyFrame(rotZCurve, frame, rotation.z)
                 
             if scaleAnimId in animIdToTimeValueMap:
-                scaXCurve = action.fcurves.new(scaleAnimPath, 0, group)
-                scaYCurve = action.fcurves.new(scaleAnimPath, 1, group)
-                scaZCurve = action.fcurves.new(scaleAnimPath, 2, group)
+                scaXCurve = action.fcurves.new(scaleAnimPath, index = 0, action_group = group)
+                scaYCurve = action.fcurves.new(scaleAnimPath, index = 1, action_group = group)
+                scaZCurve = action.fcurves.new(scaleAnimPath, index = 2, action_group = group)
                 for timeInMS, frame in zip(timeEntries, frames):
                     scale = timeToScaleMap.get(timeInMS)
                     insertLinearKeyFrame(scaXCurve, frame, scale.x)
@@ -1134,7 +1134,7 @@ class Importer:
                     meshObject.location = scene.cursor_location
                     meshObject.show_name = True
                     
-                    scene.objects.link(meshObject)
+                    scene.collection.objects.link(meshObject)
                     
                     physics_shape.meshObjectName = meshObject.name
                 
@@ -1294,7 +1294,7 @@ class Importer:
                 meshObject = bpy.data.objects.new(preferedMeshName, mesh)
                 meshObject.location = self.scene.cursor_location
                 meshObject.show_name = True
-                self.scene.objects.link(meshObject)
+                self.scene.collection.objects.link(meshObject)
 
                 mesh.m3_material_name = self.getNameOfMaterialWithReferenceIndex(m3Object.materialReferenceIndex)
                 
@@ -1387,26 +1387,26 @@ class Importer:
                 
                 for vertexUVAttribute in ["uv0", "uv1", "uv2", "uv3"]:
                     if vertexStructureDescription.hasField(vertexUVAttribute):
-                        uvTexture = mesh.uv_textures.new()
-                        uvLayer = mesh.uv_layers[len(mesh.uv_layers)-1]
+                        uvLayer = mesh.uv_layers.new()
+                        # uvLayer = mesh.uv_layers[len(mesh.uv_layers)-1]
                         for faceIndex, polygon in enumerate(mesh.polygons):
                             oldIndices = tranglesWithOldIndices[faceIndex]
                             for i in range(3):
                                 uvLayer.data[polygon.loop_start + i].uv = toBlenderUVCoordinate(getattr(m3Vertices[oldIndices[i]],vertexUVAttribute))
                             
                             
-                        if False:# old:
-                            uvLayer = mesh.tessface_uv_textures.new()
+                        # if False:# old:
+                        #     uvLayer = mesh.tessface_uv_textures.new()
 
-                            for faceIndex in range(len(trianglesWithNewIndices)):
-                                tessFace = mesh.tessfaces[faceIndex]
-                                faceUV = uvLayer.data[faceIndex]
-                                setOfOldVertexIndicesOfFace = set(tranglesWithOldIndices[faceIndex])
-                                # It's necessary to take vertex indices from tessface
-                                # Since the vertex indices may get reordered within a triangle
-                                faceUV.uv1 = getUVsFor(tessFace.vertices[0], vertexUVAttribute, setOfOldVertexIndicesOfFace)
-                                faceUV.uv2 = getUVsFor(tessFace.vertices[1], vertexUVAttribute, setOfOldVertexIndicesOfFace)
-                                faceUV.uv3 = getUVsFor(tessFace.vertices[2], vertexUVAttribute, setOfOldVertexIndicesOfFace)
+                        #     for faceIndex in range(len(trianglesWithNewIndices)):
+                        #         tessFace = mesh.tessfaces[faceIndex]
+                        #         faceUV = uvLayer.data[faceIndex]
+                        #         setOfOldVertexIndicesOfFace = set(tranglesWithOldIndices[faceIndex])
+                        #         # It's necessary to take vertex indices from tessface
+                        #         # Since the vertex indices may get reordered within a triangle
+                        #         faceUV.uv1 = getUVsFor(tessFace.vertices[0], vertexUVAttribute, setOfOldVertexIndicesOfFace)
+                        #         faceUV.uv2 = getUVsFor(tessFace.vertices[1], vertexUVAttribute, setOfOldVertexIndicesOfFace)
+                        #         faceUV.uv3 = getUVsFor(tessFace.vertices[2], vertexUVAttribute, setOfOldVertexIndicesOfFace)
 
 
                 mesh.validate()   
@@ -1420,7 +1420,7 @@ class Importer:
                         if boneName in meshObject.vertex_groups:
                             vertexGroup = meshObject.vertex_groups[boneName]
                         else:
-                            vertexGroup =  meshObject.vertex_groups.new(boneName)
+                            vertexGroup =  meshObject.vertex_groups.new(name = boneName)
                         vertexGroupLookup.append(vertexGroup)
                     for vertexIndex in range(region.firstVertexIndex,region.firstVertexIndex + region.numberOfVertices):
                         m3Vertex = m3Vertices[vertexIndex]
@@ -1444,8 +1444,8 @@ class Importer:
                     # Remove doubles after marking the sharp edges
                     # since the sharp edge detection algrithm depend on it
                     bpy.ops.object.select_all(action='DESELECT')
-                    self.scene.objects.active = meshObject
-                    meshObject.select = True
+                    self.scene.view_layers[0].objects.active = meshObject
+                    meshObject.select_set(True)
                     bpy.ops.object.mode_set(mode='EDIT') 
                     bpy.ops.mesh.select_all(action='SELECT') 
                     bpy.ops.mesh.remove_doubles()    
@@ -1469,8 +1469,8 @@ class Importer:
     def setOriginToCenter(self, meshObject):
         bpy.ops.object.mode_set(mode='OBJECT')
         bpy.ops.object.select_all(action='DESELECT')
-        self.scene.objects.active = meshObject
-        meshObject.select = True
+        self.scene.view_layers[0].objects.active = meshObject
+        meshObject.select_set(True)
         bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='MEDIAN')
     
 
@@ -1511,7 +1511,7 @@ class Importer:
                 edge = (edgeObject.vertices[1],edgeObject.vertices[0])
             if edge in uniqueEdges:
                 edgeObject.use_edge_sharp = True
-        mesh.show_edge_sharp = True
+        # mesh.show_edge_sharp = True
 
     def determineRelEditBoneMatrices(self, m3Bones, editBones):
         absEditBoneMatrices = []
@@ -1522,7 +1522,7 @@ class Importer:
             if boneEntry.parent != -1:
                 parentEditBone = editBones[boneEntry.parent]
                 absParentEditBoneMatrix = parentEditBone.matrix
-                relEditBoneMatrix = absParentEditBoneMatrix.inverted() * absEditBoneMatrix 
+                relEditBoneMatrix = absParentEditBoneMatrix.inverted() @ absEditBoneMatrix 
             else:
                 relEditBoneMatrix = absEditBoneMatrix
             relEditBoneMatrices.append(relEditBoneMatrix)
@@ -1749,7 +1749,7 @@ class Importer:
         
         self.addAnimIdData(animId, objectId=shared.animObjectIdScene, animPath=path)
         for action, timeValueMap in self.actionAndTimeValueMapPairsFor(animId):
-            curve = action.fcurves.new(path, 0)
+            curve = action.fcurves.new(path, index = 0)
             for frame, value in frameValuePairs(timeValueMap):
                 insertLinearKeyFrame(curve, frame, value)
     
@@ -1759,7 +1759,7 @@ class Importer:
         
         self.addAnimIdData(animId, objectId=shared.animObjectIdScene, animPath=path)
         for action, timeValueMap in self.actionAndTimeValueMapPairsFor(animId):
-            curve = action.fcurves.new(path, 0)
+            curve = action.fcurves.new(path, index = 0)
             for frame, value in frameValuePairs(timeValueMap):
                 insertConstantKeyFrame(curve, frame, value)
 
@@ -1771,9 +1771,9 @@ class Importer:
         
         self.addAnimIdData(animId, objectId=shared.animObjectIdScene, animPath=path)
         for action, timeValueMap in self.actionAndTimeValueMapPairsFor(animId):
-            xCurve = action.fcurves.new(path, 0)
-            yCurve = action.fcurves.new(path, 1)
-            zCurve = action.fcurves.new(path, 2)
+            xCurve = action.fcurves.new(path, index = 0)
+            yCurve = action.fcurves.new(path, index = 1)
+            zCurve = action.fcurves.new(path, index = 2)
             
             for frame, value in frameValuePairs(timeValueMap):
                 insertLinearKeyFrame(xCurve, frame, value.x)
@@ -1790,8 +1790,8 @@ class Importer:
         
         self.addAnimIdData(animId, objectId=shared.animObjectIdScene, animPath=path)
         for action, timeValueMap in self.actionAndTimeValueMapPairsFor(animId):
-            xCurve = action.fcurves.new(path, 0)
-            yCurve = action.fcurves.new(path, 1)
+            xCurve = action.fcurves.new(path, index = 0)
+            yCurve = action.fcurves.new(path, index = 1)
             
             for frame, value in frameValuePairs(timeValueMap):
                 insertLinearKeyFrame(xCurve, frame, value.x)
@@ -1805,10 +1805,10 @@ class Importer:
         
         self.addAnimIdData(animId, objectId=shared.animObjectIdScene, animPath=path)
         for action, timeValueMap in self.actionAndTimeValueMapPairsFor(animId):
-            redCurve = action.fcurves.new(path, 0)
-            greenCurve = action.fcurves.new(path, 1)
-            blueCurve = action.fcurves.new(path, 2)
-            alphaCurve = action.fcurves.new(path, 3)
+            redCurve = action.fcurves.new(path, index = 0)
+            greenCurve = action.fcurves.new(path, index = 1)
+            blueCurve = action.fcurves.new(path, index = 2)
+            alphaCurve = action.fcurves.new(path, index = 3)
 
             for frame, value in frameValuePairs(timeValueMap):
                 v = toBlenderColorVector(value)
@@ -1832,13 +1832,13 @@ class Importer:
         # since they all would result in the same longAnimId (see getLongAnimIdOf):
         self.addAnimIdData(animId, objectId=shared.animObjectIdScene, animPath=animPathMinBorder)
         for action, timeValueMap in self.actionAndTimeValueMapPairsFor(animId):
-            minXCurve = action.fcurves.new(animPathMinBorder, 0)
-            minYCurve = action.fcurves.new(animPathMinBorder, 1)
-            minZCurve = action.fcurves.new(animPathMinBorder, 2)
-            maxXCurve = action.fcurves.new(animPathMaxBorder, 0)
-            maxYCurve = action.fcurves.new(animPathMaxBorder, 1)
-            maxZCurve = action.fcurves.new(animPathMaxBorder, 2)
-            radiusCurve = action.fcurves.new(animPathRadius, 0)
+            minXCurve = action.fcurves.new(animPathMinBorder, index = 0)
+            minYCurve = action.fcurves.new(animPathMinBorder, index = 1)
+            minZCurve = action.fcurves.new(animPathMinBorder, index = 2)
+            maxXCurve = action.fcurves.new(animPathMaxBorder, index = 0)
+            maxYCurve = action.fcurves.new(animPathMaxBorder, index = 1)
+            maxZCurve = action.fcurves.new(animPathMaxBorder, index = 2)
+            radiusCurve = action.fcurves.new(animPathRadius, index = 0)
             
             for frame, value in frameValuePairs(timeValueMap):
                 insertLinearKeyFrame(minXCurve, frame, value.minBorder.x)
@@ -1872,7 +1872,7 @@ def boneRotMatrix(head, tail, roll):
             (0, 0, 1)))
     
     rMatrix = mathutils.Matrix.Rotation(roll, 3, v)
-    return rMatrix *bMatrix
+    return rMatrix @bMatrix
 
 def boneMatrix(head, tail, roll):
     """unused: how blender calculates the matrix of a bone """

--- a/shared.py
+++ b/shared.py
@@ -162,7 +162,7 @@ def setDefaultValue(defaultAction, path, index, value):
             curve = c
             break
     if curve == None:
-        curve = defaultAction.fcurves.new(path, index)
+        curve = defaultAction.fcurves.new(path, index = index)
     keyFrame = curve.keyframe_points.insert(0, value)
     keyFrame.interpolation = "CONSTANT"
 
@@ -899,7 +899,7 @@ def composeMatrix(location, rotation, scale):
     scaleMatrix = mathutils.Matrix()
     for i in range(3):
         scaleMatrix[i][i] = scale[i]
-    return locMatrix * rotationMatrix * scaleMatrix
+    return locMatrix @ rotationMatrix @ scaleMatrix
             
 def getLongAnimIdOf(objectId, animPath):
     if objectId == animObjectIdScene and animPath.startswith("m3_boundings"):
@@ -921,13 +921,15 @@ def createHiddenMeshObject(name, untransformedPositions, faces, matrix):
 
     transformedPositions = []
     for v in untransformedPositions:
-        transformedPositions.append(matrix * mathutils.Vector(v))
+        transformedPositions.append(matrix @ mathutils.Vector(v))
 
-    mesh.vertices.add(len(transformedPositions))
-    mesh.vertices.foreach_set("co", io_utils.unpack_list(transformedPositions))
+    mesh.from_pydata(transformedPositions, [], faces)
 
-    mesh.tessfaces.add(len(faces))
-    mesh.tessfaces.foreach_set("vertices_raw", io_utils.unpack_face_list(faces))
+    # mesh.vertices.add(len(transformedPositions))
+    #mesh.vertices.foreach_set("co", io_utils.unpack_list(transformedPositions))
+
+    # mesh.loop_triangles.add(len(faces))
+    # mesh.loop_triangles.foreach_set("vertices", io_utils.unpack_face_list(faces))
     
     mesh.update(calc_edges=True)
     return meshObject
@@ -1119,7 +1121,7 @@ def createPhysicsShapeMeshData(shape):
         faces = [f.vertices for f in mesh.polygons]
     
     matrix = composeMatrix(shape.offset, shape.rotationEuler, shape.scale)
-    vertices = [matrix * mathutils.Vector(v) for v in vertices]
+    vertices = [matrix @ mathutils.Vector(v) for v in vertices]
     
     return vertices, faces
 
@@ -1156,14 +1158,14 @@ def removeRigidBodyBoneShape(scene, rigidBody):
 
 def updateBoneShape(bone, poseBone, meshName, untransformedPositions, faces, matrix=mathutils.Matrix()):
     # Undo the rotation fix:
-    matrix = rotFixMatrixInverted * matrix
+    matrix = rotFixMatrixInverted @ matrix
     boneScale = (bone.head - bone.tail).length
     invertedBoneScale = 1.0 / boneScale
     scaleMatrix = mathutils.Matrix()
     scaleMatrix[0][0] = invertedBoneScale
     scaleMatrix[1][1] = invertedBoneScale
     scaleMatrix[2][2] = invertedBoneScale
-    matrix = scaleMatrix * matrix
+    matrix = scaleMatrix @ matrix
     
     #TODO reuse existing mesh of bone if it exists
     poseBone.custom_shape = createHiddenMeshObject(meshName, untransformedPositions, faces, matrix)


### PR DESCRIPTION
# I strongly recommend that you *do not* merge this into master.

Blender 2.80 has a TON of API changes such as the removal of tessfaces and uses new python features such as:
https://www.python.org/dev/peps/pep-0526/
and:
https://www.python.org/dev/peps/pep-0465/

I haven't updated all of the logic for exporting, as that still uses tessfaces so it will error (see `#TODO` comments.)

I've tested a few M3 and M3a files from Starcraft 2 and Heroes of the Storm, they seem to be working.